### PR TITLE
chore: add missing pnpm-workspace.yaml file

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'packages/*'
+  - 'apps/*'
+


### PR DESCRIPTION
## 개요

- 루트 디렉토리에 pnpm-workspace 파일이 누락되어 백엔드 개발 브랜치에 해당 파일을 추가했습니다.

## 이슈

- #8 
