### PR TITLE
feat(fe): add modal management context and custom hook

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -41,4 +41,5 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --quiet || { git add . && git commit -m 'chore: auto-fix linting and formatting issues' && git push origin ${{ github.head_ref }}; }
+          branch_name="${{ github.head_ref }}"
+          git diff --quiet || { git add . && git commit -m 'chore: auto-fix linting and formatting issues' && git push origin "$branch_name"; }

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -41,4 +41,4 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --quiet || (git add . && git commit -m 'chore: auto-fix linting and formatting issues' && git push origin ${{ github.head_ref }})
+          git diff --quiet || { git add . && git commit -m 'chore: auto-fix linting and formatting issues' && git push origin ${{ github.head_ref }}; }

--- a/apps/client/src/features/modal/components/Background.tsx
+++ b/apps/client/src/features/modal/components/Background.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+
+function Background({
+  children,
+  onClick,
+}: PropsWithChildren<{ onClick: () => void }>) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className='fixed left-0 top-0 z-10 flex h-dvh w-dvw cursor-auto items-center justify-center bg-[#808080]/20 backdrop-blur-sm'
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Background;

--- a/apps/client/src/features/modal/index.ts
+++ b/apps/client/src/features/modal/index.ts
@@ -1,0 +1,1 @@
+export * from './modal.hook';

--- a/apps/client/src/features/modal/modal.context.ts
+++ b/apps/client/src/features/modal/modal.context.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export interface ModalContextProps {
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+export const ModalContext = createContext<ModalContextProps | undefined>(
+  undefined,
+);

--- a/apps/client/src/features/modal/modal.hook.tsx
+++ b/apps/client/src/features/modal/modal.hook.tsx
@@ -1,0 +1,54 @@
+import { ReactNode, useContext, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import Background from '@/features/modal/components/Background';
+import { ModalContext } from '@/features/modal/modal.context';
+
+export const useModal = (children: ReactNode) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => setIsOpen(true);
+
+  const closeModal = () => setIsOpen(false);
+
+  const contextValue = useMemo(() => ({ openModal, closeModal }), []);
+
+  const Modal = useMemo(() => {
+    if (!isOpen) return null;
+    return createPortal(
+      <ModalContext.Provider value={contextValue}>
+        <Background onClick={closeModal}>
+          <div
+            role='button'
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation();
+              }
+            }}
+          >
+            {children}
+          </div>
+        </Background>
+      </ModalContext.Provider>,
+      document.body,
+    );
+  }, [isOpen, children, contextValue]);
+
+  return {
+    Modal,
+    openModal,
+    closeModal,
+  };
+};
+
+export const useModalContext = () => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error('useModalContext must be used within a ModalProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## 개요

- 모달을 사용하기 위해 아래 내용을 추가했습니다.
  - 모달을 관리하는 Context 추가
  - 모달을 생성하고 접근할 수 있는 커스텀 훅 추가
- 브랜치 이름에 괄호를 추가하여, 깃헙 액션에 오류가 발생하여 해당 부분 수정합니다.

## 이슈

- close #25 
