### PR TITLE
feat(fe): add chat and Q&A management slices with session store

### DIFF
--- a/apps/client/src/features/session/chatting/chatting.slice.ts
+++ b/apps/client/src/features/session/chatting/chatting.slice.ts
@@ -1,0 +1,19 @@
+import { StateCreator } from 'zustand';
+
+import { Chat } from '@/features/session/chatting';
+
+export interface ChattingSlice {
+  chatting: Chat[];
+  addChatting: (chat: Chat) => void;
+}
+
+export const createChattingSlice: StateCreator<
+  ChattingSlice,
+  [],
+  [],
+  ChattingSlice
+> = (set) => ({
+  chatting: [],
+  addChatting: (chat) =>
+    set((state) => ({ chatting: [...state.chatting, chat] })),
+});

--- a/apps/client/src/features/session/chatting/chatting.slice.ts
+++ b/apps/client/src/features/session/chatting/chatting.slice.ts
@@ -4,6 +4,7 @@ import { Chat } from '@/features/session/chatting';
 
 export interface ChattingSlice {
   chatting: Chat[];
+  resetChatting: () => void;
   addChatting: (chat: Chat) => void;
 }
 
@@ -14,6 +15,7 @@ export const createChattingSlice: StateCreator<
   ChattingSlice
 > = (set) => ({
   chatting: [],
+  resetChatting: () => set({ chatting: [] }),
   addChatting: (chat) =>
     set((state) => ({ chatting: [...state.chatting, chat] })),
 });

--- a/apps/client/src/features/session/chatting/chatting.type.ts
+++ b/apps/client/src/features/session/chatting/chatting.type.ts
@@ -1,0 +1,8 @@
+export interface Chat {
+  id: string;
+  body: string;
+  user: {
+    token: string;
+    nickname: string;
+  };
+}

--- a/apps/client/src/features/session/chatting/index.ts
+++ b/apps/client/src/features/session/chatting/index.ts
@@ -1,0 +1,2 @@
+export * from './chatting.type';
+export * from './chatting.slice';

--- a/apps/client/src/features/session/index.ts
+++ b/apps/client/src/features/session/index.ts
@@ -1,0 +1,1 @@
+export * from './session.store';

--- a/apps/client/src/features/session/qa/index.ts
+++ b/apps/client/src/features/session/qa/index.ts
@@ -1,0 +1,2 @@
+export * from './qa.type';
+export * from './qa.slice';

--- a/apps/client/src/features/session/qa/qa.slice.ts
+++ b/apps/client/src/features/session/qa/qa.slice.ts
@@ -7,12 +7,12 @@ export interface QASlice {
   resetQuestions: () => void;
   addQuestion: (question: Question) => void;
   updateQuestion: (question: Question) => void;
-  removeQuestion: (questionId: Question['id']) => void;
-  upvoteQuestion: (questionId: Question['id']) => void;
+  removeQuestion: (question: Question) => void;
+  upvoteQuestion: (question: Question) => void;
   addReply: (reply: Reply) => void;
   updateReply: (reply: Reply) => void;
-  removeReply: (replyId: Reply['id']) => void;
-  upvoteReply: (replyId: Reply['id']) => void;
+  removeReply: (reply: Reply) => void;
+  upvoteReply: (reply: Reply) => void;
 }
 
 export const createQASlice: StateCreator<QASlice, [], [], QASlice> = (set) => ({
@@ -27,16 +27,16 @@ export const createQASlice: StateCreator<QASlice, [], [], QASlice> = (set) => ({
         q.id === question.id ? question : q,
       ),
     })),
-  removeQuestion: (questionId) =>
+  removeQuestion: (question) =>
     set((state) => ({
       ...state,
-      questions: state.questions.filter((q) => q.id !== questionId),
+      questions: state.questions.filter((q) => q.id !== question.id),
     })),
-  upvoteQuestion: (questionId) =>
+  upvoteQuestion: (question) =>
     set((state) => ({
       ...state,
       questions: state.questions.map((q) =>
-        q.id === questionId ? { ...q, upvotes: q.upvotes + 1 } : q,
+        q.id === question.id ? { ...q, upvotes: q.upvotes + 1 } : q,
       ),
     })),
   addReply: (reply) =>
@@ -60,21 +60,21 @@ export const createQASlice: StateCreator<QASlice, [], [], QASlice> = (set) => ({
           : q,
       ),
     })),
-  removeReply: (replyId) =>
+  removeReply: (reply) =>
     set((state) => ({
       ...state,
       questions: state.questions.map((q) => ({
         ...q,
-        replies: q.replies.filter((r) => r.id !== replyId),
+        replies: q.replies.filter((r) => r.id !== reply.id),
       })),
     })),
-  upvoteReply: (replyId) =>
+  upvoteReply: (reply) =>
     set((state) => ({
       ...state,
       questions: state.questions.map((q) => ({
         ...q,
         replies: q.replies.map((r) =>
-          r.id === replyId ? { ...r, upvotes: r.upvotes + 1 } : r,
+          r.id === reply.id ? { ...r, upvotes: r.upvotes + 1 } : r,
         ),
       })),
     })),

--- a/apps/client/src/features/session/qa/qa.slice.ts
+++ b/apps/client/src/features/session/qa/qa.slice.ts
@@ -4,6 +4,7 @@ import { Question, Reply } from '@/features/session/qa/qa.type';
 
 export interface QASlice {
   questions: Question[];
+  resetQuestions: () => void;
   addQuestion: (question: Question) => void;
   updateQuestion: (question: Question) => void;
   removeQuestion: (questionId: Question['id']) => void;
@@ -16,6 +17,7 @@ export interface QASlice {
 
 export const createQASlice: StateCreator<QASlice, [], [], QASlice> = (set) => ({
   questions: [],
+  resetQuestions: () => set({ questions: [] }),
   addQuestion: (question) =>
     set((state) => ({ ...state, questions: [...state.questions, question] })),
   updateQuestion: (question) =>

--- a/apps/client/src/features/session/qa/qa.slice.ts
+++ b/apps/client/src/features/session/qa/qa.slice.ts
@@ -1,0 +1,79 @@
+import { StateCreator } from 'zustand/index';
+
+import { Question, Reply } from '@/features/session/qa/qa.type';
+
+export interface QASlice {
+  questions: Question[];
+  addQuestion: (question: Question) => void;
+  updateQuestion: (question: Question) => void;
+  removeQuestion: (questionId: Question['id']) => void;
+  upvoteQuestion: (questionId: Question['id']) => void;
+  addReply: (reply: Reply) => void;
+  updateReply: (reply: Reply) => void;
+  removeReply: (replyId: Reply['id']) => void;
+  upvoteReply: (replyId: Reply['id']) => void;
+}
+
+export const createQASlice: StateCreator<QASlice, [], [], QASlice> = (set) => ({
+  questions: [],
+  addQuestion: (question) =>
+    set((state) => ({ ...state, questions: [...state.questions, question] })),
+  updateQuestion: (question) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.map((q) =>
+        q.id === question.id ? question : q,
+      ),
+    })),
+  removeQuestion: (questionId) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.filter((q) => q.id !== questionId),
+    })),
+  upvoteQuestion: (questionId) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.map((q) =>
+        q.id === questionId ? { ...q, upvotes: q.upvotes + 1 } : q,
+      ),
+    })),
+  addReply: (reply) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.map((q) =>
+        q.id === reply.questionId
+          ? { ...q, replies: [...q.replies, reply] }
+          : q,
+      ),
+    })),
+  updateReply: (reply) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.map((q) =>
+        q.id === reply.questionId
+          ? {
+              ...q,
+              replies: q.replies.map((r) => (r.id === reply.id ? reply : r)),
+            }
+          : q,
+      ),
+    })),
+  removeReply: (replyId) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.map((q) => ({
+        ...q,
+        replies: q.replies.filter((r) => r.id !== replyId),
+      })),
+    })),
+  upvoteReply: (replyId) =>
+    set((state) => ({
+      ...state,
+      questions: state.questions.map((q) => ({
+        ...q,
+        replies: q.replies.map((r) =>
+          r.id === replyId ? { ...r, upvotes: r.upvotes + 1 } : r,
+        ),
+      })),
+    })),
+});

--- a/apps/client/src/features/session/qa/qa.type.ts
+++ b/apps/client/src/features/session/qa/qa.type.ts
@@ -1,0 +1,28 @@
+import { Session } from '@/features/session';
+
+export interface Question {
+  id: number;
+  sessionId: Session['id'];
+  body: string;
+  closed: boolean;
+  pinned: boolean;
+  upvotes: number;
+  replies: Reply[];
+  user: {
+    token: string;
+    nickname: string;
+  };
+  createdAt: string;
+}
+
+export interface Reply {
+  id: number;
+  questionId: Question['id'];
+  body: string;
+  user: {
+    token: string;
+    nickname: string;
+  };
+  upvotes: number;
+  createdAt: string;
+}

--- a/apps/client/src/features/session/session.slice.ts
+++ b/apps/client/src/features/session/session.slice.ts
@@ -1,0 +1,18 @@
+import { StateCreator } from 'zustand/index';
+
+import { Session } from '@/features/session/session.type';
+
+export interface SessionSlice {
+  session?: Session;
+  setSession: (session: Session) => void;
+}
+
+export const createSessionSlice: StateCreator<
+  SessionSlice,
+  [],
+  [],
+  SessionSlice
+> = (set) => ({
+  session: undefined,
+  setSession: (session) => set({ session }),
+});

--- a/apps/client/src/features/session/session.slice.ts
+++ b/apps/client/src/features/session/session.slice.ts
@@ -1,18 +1,26 @@
 import { StateCreator } from 'zustand/index';
 
+import { ChattingSlice } from '@/features/session/chatting';
+import { QASlice } from '@/features/session/qa';
 import { Session } from '@/features/session/session.type';
 
 export interface SessionSlice {
   session?: Session;
+  reset: () => void;
   setSession: (session: Session) => void;
 }
 
 export const createSessionSlice: StateCreator<
-  SessionSlice,
+  SessionSlice & QASlice & ChattingSlice,
   [],
   [],
   SessionSlice
-> = (set) => ({
+> = (set, get) => ({
   session: undefined,
+  reset: () => {
+    get().resetQuestions();
+    get().resetChatting();
+    set({ session: undefined });
+  },
   setSession: (session) => set({ session }),
 });

--- a/apps/client/src/features/session/session.store.ts
+++ b/apps/client/src/features/session/session.store.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+import {
+  ChattingSlice,
+  createChattingSlice,
+} from '@/features/session/chatting';
+import { createQASlice, QASlice } from '@/features/session/qa';
+import {
+  createSessionSlice,
+  SessionSlice,
+} from '@/features/session/session.slice';
+
+export type SessionStore = SessionSlice & QASlice & ChattingSlice;
+
+export const useSessionStore = create<SessionStore>()((...a) => ({
+  ...createQASlice(...a),
+  ...createChattingSlice(...a),
+  ...createSessionSlice(...a),
+}));

--- a/apps/client/src/features/session/session.type.ts
+++ b/apps/client/src/features/session/session.type.ts
@@ -1,0 +1,6 @@
+export interface Session {
+  id: string;
+  title: string;
+  expiredAt: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## 개요

- Q&A의 질문 및 답변 전역 상태 관리를 위한 타입과 액션을 추가했습니다.
- 채팅 전역 상태 관리를 위한 타입과 액션을 추가했습니다.

## 추가 내용
- 데이터들의 타입은 임시로 ERD을 참고하여 작성했습니다. 이후에 제공되는 DTO에 따라 수정하는 방식으로 진행하거나, 어댑터를 추가하여 진행하겠습니다.

## 이슈

- close #27 
