### PR TITLE
refactor: remove develop branches from PR workflow

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -2,7 +2,7 @@ name: Lint & Format
 
 on:
   pull_request:
-    branches: ['main', 'develop-fe', 'develop-be']
+    branches: ['main']
 
 jobs:
   lint:


### PR DESCRIPTION
## 개요

- lint-format.yml에서 pull_request 대상 브랜치 중 `develop-be` `develop-fe` 없앴습니다.
- 도메인(fe/be)을 설정하기 애매해서 일단 없는 상태로 작성했습니다.

## 이슈

- close #38 
