### PR TITLE
Feat(be): user session token

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -34,7 +34,8 @@
     "prisma": "^5.21.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.0.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/apps/server/prisma/migrations/20241109165716_init/migration.sql
+++ b/apps/server/prisma/migrations/20241109165716_init/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "User_Session_Token" (
+    "token" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "Session_id" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_Session_Token_token_key" ON "User_Session_Token"("token");

--- a/apps/server/prisma/migrations/20241109170330_init/migration.sql
+++ b/apps/server/prisma/migrations/20241109170330_init/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the `User_Session_Token` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "User_Session_Token";
+
+-- CreateTable
+CREATE TABLE "UserSessionToken" (
+    "token" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "Session_id" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSessionToken_token_key" ON "UserSessionToken"("token");

--- a/apps/server/prisma/migrations/20241109170857_init/migration.sql
+++ b/apps/server/prisma/migrations/20241109170857_init/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `Session_id` on the `UserSessionToken` table. All the data in the column will be lost.
+  - Added the required column `session_id` to the `UserSessionToken` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "UserSessionToken" DROP COLUMN "Session_id",
+ADD COLUMN     "session_id" TEXT NOT NULL;

--- a/apps/server/prisma/migrations/20241109181624_init/migration.sql
+++ b/apps/server/prisma/migrations/20241109181624_init/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "UserSessionToken_token_key";
+
+-- AlterTable
+ALTER TABLE "UserSessionToken" ADD CONSTRAINT "UserSessionToken_pkey" PRIMARY KEY ("token");

--- a/apps/server/prisma/migrations/20241110141915_init/migration.sql
+++ b/apps/server/prisma/migrations/20241110141915_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserSessionToken" ALTER COLUMN "user_id" DROP NOT NULL;

--- a/apps/server/prisma/migrations/20241110152007_init/migration.sql
+++ b/apps/server/prisma/migrations/20241110152007_init/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - The `user_id` column on the `UserSessionToken` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "UserSessionToken" DROP COLUMN "user_id",
+ADD COLUMN     "user_id" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_create_user_id_fkey" FOREIGN KEY ("create_user_id") REFERENCES "User"("user_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserSessionToken" ADD CONSTRAINT "UserSessionToken_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserSessionToken" ADD CONSTRAINT "UserSessionToken_session_id_fkey" FOREIGN KEY ("session_id") REFERENCES "Session"("session_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/server/prisma/migrations/20241110160147_init/migration.sql
+++ b/apps/server/prisma/migrations/20241110160147_init/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `user_id` to the `Session` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_create_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "user_id" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("user_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/server/prisma/migrations/20241110160251_init/migration.sql
+++ b/apps/server/prisma/migrations/20241110160251_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `create_user_id` on the `Session` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Session" DROP COLUMN "create_user_id";

--- a/apps/server/prisma/migrations/20241110160419_init/migration.sql
+++ b/apps/server/prisma/migrations/20241110160419_init/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `user_id` on the `Session` table. All the data in the column will be lost.
+  - Added the required column `created_user_id` to the `Session` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "Session" DROP COLUMN "user_id",
+ADD COLUMN     "created_user_id" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_created_user_id_fkey" FOREIGN KEY ("created_user_id") REFERENCES "User"("user_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -22,3 +22,9 @@ model Session {
   expired_at DateTime
   created_at DateTime @default(now())
 }
+
+model UserSessionToken {
+  token String @id @default(uuid())
+  user_id String
+  session_id String
+}

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -13,6 +13,8 @@ model User {
   password   String
   nickname   String   @unique
   created_at DateTime @default(now())
+  sessions Session[] @relation("UserSessions")
+  userSessionTokens UserSessionToken[] @relation("UserTokens")
 }
 
 model Session {
@@ -21,10 +23,16 @@ model Session {
   title String
   expired_at DateTime
   created_at DateTime @default(now())
+
+  user              User              @relation("UserSessions", fields: [create_user_id], references: [user_id])
+  userSessionTokens UserSessionToken[] @relation("SessionTokens")
 }
 
 model UserSessionToken {
   token String @id @default(uuid())
-  user_id String?
+  user_id Int?
   session_id String
+
+  user    User?       @relation("UserTokens", fields: [user_id], references: [user_id])
+  session Session     @relation("SessionTokens", fields: [session_id], references: [session_id])
 }

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -19,13 +19,13 @@ model User {
 
 model Session {
   session_id String @id @default(uuid())
-  create_user_id Int
   title String
   expired_at DateTime
   created_at DateTime @default(now())
 
-  user              User              @relation("UserSessions", fields: [create_user_id], references: [user_id])
-  userSessionTokens UserSessionToken[] @relation("SessionTokens")
+  user               User              @relation("UserSessions", fields: [created_user_id], references: [user_id]) 
+  created_user_id            Int
+  userSessionTokens  UserSessionToken[] @relation("SessionTokens")
 }
 
 model UserSessionToken {

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -25,6 +25,6 @@ model Session {
 
 model UserSessionToken {
   token String @id @default(uuid())
-  user_id String
+  user_id String?
   session_id String
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -3,9 +3,10 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from './prisma/prisma.module';
 import { PrismaService } from './prisma/prisma.service';
 import { SessionsModule } from './sessions/sessions.module';
+import { SessionsAuthModule } from './sessions-auth/sessions-auth.module';
 import { UsersModule } from './users/users.module';
 @Module({
-  imports: [UsersModule, PrismaModule, SessionsModule],
+  imports: [UsersModule, PrismaModule, SessionsModule, SessionsAuthModule, SessionsAuthModule],
   controllers: [],
   providers: [PrismaService],
 })

--- a/apps/server/src/sessions-auth/dto/session-auth.dto.ts
+++ b/apps/server/src/sessions-auth/dto/session-auth.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional } from 'class-validator';
+
+export class SessionAuthDto {
+  @ApiProperty({
+    example: 'jangnanGGuruki',
+    description: '유저의 id',
+    required: false,
+  })
+  @IsOptional()
+  user_id: string;
+
+  @ApiProperty({
+    example: 'ew9sqwe3dsf9xcv08xcv',
+    description: 'session의 id',
+    required: true,
+  })
+  @IsNotEmpty()
+  session_id: string;
+
+  @ApiProperty({
+    example: 'wer8sdf8xcv8cxv8cxv89',
+    description: 'client에서 확인한 해당 세션에 대한 토큰 값',
+    required: false,
+  })
+  @IsOptional()
+  token: string;
+}

--- a/apps/server/src/sessions-auth/dto/session-auth.dto.ts
+++ b/apps/server/src/sessions-auth/dto/session-auth.dto.ts
@@ -3,12 +3,12 @@ import { IsNotEmpty, IsOptional } from 'class-validator';
 
 export class SessionAuthDto {
   @ApiProperty({
-    example: 'jangnanGGuruki',
+    example: '291',
     description: '유저의 id',
     required: false,
   })
   @IsOptional()
-  user_id: string;
+  user_id: number;
 
   @ApiProperty({
     example: 'ew9sqwe3dsf9xcv08xcv',

--- a/apps/server/src/sessions-auth/sessions-auth.controller.spec.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.controller.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { SessionsAuthController } from './sessions-auth.controller';
+
+describe('SessionsAuthController', () => {
+  let controller: SessionsAuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SessionsAuthController],
+    }).compile();
+
+    controller = module.get<SessionsAuthController>(SessionsAuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/server/src/sessions-auth/sessions-auth.controller.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { SessionAuthDto } from './dto/session-auth.dto';
+import { SessionsAuthService } from './sessions-auth.service';
+
+@ApiTags('session-auth')
+@Controller('sessions-auth')
+export class SessionsAuthController {
+  constructor(private readonly sessionsAuthService: SessionsAuthService) {}
+
+  @Get()
+  async checkToken(@Query() sessionAuthDto: SessionAuthDto) {
+    return {
+      type: 'success',
+      data: {
+        token: await this.sessionsAuthService.validateOrCreateToken(sessionAuthDto),
+      },
+    };
+  }
+}

--- a/apps/server/src/sessions-auth/sessions-auth.controller.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.controller.ts
@@ -3,13 +3,15 @@ import { ApiTags } from '@nestjs/swagger';
 
 import { SessionAuthDto } from './dto/session-auth.dto';
 import { SessionsAuthService } from './sessions-auth.service';
-
+import { AuthSessionsSwagger } from './swagger/sessions-auth.swagger';
 @ApiTags('session-auth')
 @Controller('sessions-auth')
 export class SessionsAuthController {
   constructor(private readonly sessionsAuthService: SessionsAuthService) {}
 
   @Get()
+  @AuthSessionsSwagger.ApiOperation
+  @AuthSessionsSwagger.ApiResponse200
   async checkToken(@Query() sessionAuthDto: SessionAuthDto) {
     return {
       type: 'success',

--- a/apps/server/src/sessions-auth/sessions-auth.module.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { SessionsAuthController } from './sessions-auth.controller';
+import { SessionsAuthRepository } from './sessions-auth.repository';
+import { SessionsAuthService } from './sessions-auth.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SessionsAuthController],
+  providers: [SessionsAuthService, SessionsAuthRepository],
+})
+export class SessionsAuthModule {}

--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { v4 as uuid4 } from 'uuid';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { SessionAuthDto } from './dto/session-auth.dto';
+
+@Injectable()
+export class SessionsAuthRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createToken(data: SessionAuthDto) {
+    const result = await this.prisma.userSessionToken.create({
+      data: {
+        ...data,
+        token: uuid4(), // 새로운 UUID 생성하여 token 필드에 할당
+      },
+    });
+    return result.token;
+  }
+
+  async updateToken(data: SessionAuthDto) {
+    const newToken = uuid4();
+    await this.prisma.userSessionToken.updateMany({
+      where: {
+        session_id: data.session_id,
+        user_id: data.user_id,
+      },
+      data: {
+        token: newToken,
+      },
+    });
+    return newToken;
+  }
+
+  async findToken(user_id: string | null, session_id: string, token: string) {
+    return await this.prisma.userSessionToken.findFirst({
+      where: {
+        session_id,
+        token,
+        ...(user_id !== null && { user_id }),
+      },
+    });
+  }
+}

--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -19,9 +19,9 @@ export class SessionsAuthRepository {
   }
 
   async generateTokenForLogined(data: SessionAuthDto) {
+    const result = await this.findToken(data.user_id, data.session_id, null);
+    if (result) return result;
     const newToken = await this.generateTokenForNotLogined(data);
-    const deletedToken = await this.findToken(data.user_id, data.session_id, null);
-    await this.deleteToken(deletedToken);
     return newToken;
   }
 

--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -8,7 +8,7 @@ import { SessionAuthDto } from './dto/session-auth.dto';
 export class SessionsAuthRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async generateTokenForNotLogined(data: SessionAuthDto) {
+  async generateTokenForNotLoggedin(data: SessionAuthDto) {
     const newUserSessionToken = await this.prisma.userSessionToken.create({
       data: {
         ...data,
@@ -18,10 +18,10 @@ export class SessionsAuthRepository {
     return newUserSessionToken.token;
   }
 
-  async generateTokenForLogined(data: SessionAuthDto) {
+  async generateTokenForLoggedin(data: SessionAuthDto) {
     const result = await this.findToken(data.user_id, data.session_id, null);
     if (result) return result;
-    const newToken = await this.generateTokenForNotLogined(data);
+    const newToken = await this.generateTokenForNotLoggedin(data);
     return newToken;
   }
 

--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -8,7 +8,7 @@ import { SessionAuthDto } from './dto/session-auth.dto';
 export class SessionsAuthRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async generateTokenForNotLoggedin(data: SessionAuthDto) {
+  async generateToken(data: SessionAuthDto) {
     const newUserSessionToken = await this.prisma.userSessionToken.create({
       data: {
         ...data,
@@ -21,7 +21,7 @@ export class SessionsAuthRepository {
   async generateTokenForLoggedin(data: SessionAuthDto) {
     const result = await this.findToken(data.user_id, data.session_id, null);
     if (result) return result;
-    const newToken = await this.generateTokenForNotLoggedin(data);
+    const newToken = await this.generateToken(data);
     return newToken;
   }
 

--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -12,6 +12,7 @@ export class SessionsAuthRepository {
     const newUserSessionToken = await this.prisma.userSessionToken.create({
       data: {
         ...data,
+        user_id: data.user_id ? Number(data.user_id) : null,
         token: uuid4(),
       },
     });
@@ -25,13 +26,14 @@ export class SessionsAuthRepository {
     return newToken;
   }
 
-  async findToken(user_id: string | null, session_id: string, token: string) {
+  async findToken(user_id: number | null, session_id: string, token: string) {
+    const whereClause: any = {
+      session_id,
+    };
+    if (user_id != null) whereClause.user_id = Number(user_id);
+    if (token) whereClause.token = token;
     const findedToken = await this.prisma.userSessionToken.findFirst({
-      where: {
-        session_id,
-        ...(user_id ? { user_id } : {}),
-        ...(token ? { token } : {}),
-      },
+      where: whereClause,
       select: {
         token: true,
       },

--- a/apps/server/src/sessions-auth/sessions-auth.service.spec.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { SessionsAuthService } from './sessions-auth.service';
+
+describe('SessionsAuthService', () => {
+  let service: SessionsAuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SessionsAuthService],
+    }).compile();
+
+    service = module.get<SessionsAuthService>(SessionsAuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/server/src/sessions-auth/sessions-auth.service.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.service.ts
@@ -12,10 +12,9 @@ export class SessionsAuthService {
 
     if (!token) {
       const result = user_id ? await this.sessionsAuthRepository.findToken(user_id, session_id, token) : null;
-      return result || (await this.sessionsAuthRepository.generateTokenForNotLoggedin({ ...data }));
+      return result || (await this.sessionsAuthRepository.generateToken(data));
     } else {
-      const result = await this.sessionsAuthRepository.findToken(user_id, session_id, token);
-      return result ? result : await this.sessionsAuthRepository.generateTokenForLoggedin({ ...data });
+      return await this.sessionsAuthRepository.generateTokenForLoggedin(data);
     }
   }
 }

--- a/apps/server/src/sessions-auth/sessions-auth.service.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.service.ts
@@ -12,10 +12,10 @@ export class SessionsAuthService {
 
     if (!token) {
       const result = user_id ? await this.sessionsAuthRepository.findToken(user_id, session_id, token) : null;
-      return result || (await this.sessionsAuthRepository.generateTokenForNotLogined({ ...data }));
+      return result || (await this.sessionsAuthRepository.generateTokenForNotLoggedin({ ...data }));
     } else {
       const result = await this.sessionsAuthRepository.findToken(user_id, session_id, token);
-      return result ? result : await this.sessionsAuthRepository.generateTokenForLogined({ ...data });
+      return result ? result : await this.sessionsAuthRepository.generateTokenForLoggedin({ ...data });
     }
   }
 }

--- a/apps/server/src/sessions-auth/sessions-auth.service.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.service.ts
@@ -11,10 +11,11 @@ export class SessionsAuthService {
     const { session_id, user_id, token } = data;
 
     if (!token) {
-      return await this.sessionsAuthRepository.createToken({ ...data });
+      const result = user_id ? await this.sessionsAuthRepository.findToken(user_id, session_id, token) : null;
+      return result || (await this.sessionsAuthRepository.generateTokenForNotLogined({ ...data }));
     } else {
       const result = await this.sessionsAuthRepository.findToken(user_id, session_id, token);
-      return result ? { token: result.token } : await this.sessionsAuthRepository.updateToken({ ...data });
+      return result ? result : await this.sessionsAuthRepository.generateTokenForLogined({ ...data });
     }
   }
 }

--- a/apps/server/src/sessions-auth/sessions-auth.service.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+import { SessionAuthDto } from './dto/session-auth.dto';
+import { SessionsAuthRepository } from './sessions-auth.repository';
+
+@Injectable()
+export class SessionsAuthService {
+  constructor(private readonly sessionsAuthRepository: SessionsAuthRepository) {}
+
+  async validateOrCreateToken(data: SessionAuthDto) {
+    const { session_id, user_id, token } = data;
+
+    if (!token) {
+      return await this.sessionsAuthRepository.createToken({ ...data });
+    } else {
+      const result = await this.sessionsAuthRepository.findToken(user_id, session_id, token);
+      return result ? { token: result.token } : await this.sessionsAuthRepository.updateToken({ ...data });
+    }
+  }
+}

--- a/apps/server/src/sessions-auth/swagger/sessions-auth.swagger.ts
+++ b/apps/server/src/sessions-auth/swagger/sessions-auth.swagger.ts
@@ -1,0 +1,17 @@
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const AuthSessionsSwagger = {
+  ApiOperation: ApiOperation({ summary: '세션에 대한 사용자 검증' }),
+  ApiResponse200: ApiResponse({
+    status: 200,
+    description: '세션 auth 요청 성공',
+    schema: {
+      example: {
+        type: 'success',
+        data: {
+          token: '21dad221-f42c-4edf-b1ca-e63e2360f943',
+        },
+      },
+    },
+  }),
+};

--- a/apps/server/src/sessions/sessions.service.ts
+++ b/apps/server/src/sessions/sessions.service.ts
@@ -15,7 +15,9 @@ export class SessionsService {
     const sessionData = {
       ...data,
       expired_at: expired_at,
-      create_user_id: 123,
+      user: {
+        connect: { user_id: 1 },
+      },
     };
     const createdSession = await this.sessionRepository.create(sessionData);
     return { sessionId: createdSession.session_id };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@4.21.1)
+      uuid:
+        specifier: ^11.0.2
+        version: 11.0.2
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -4409,6 +4412,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.0.2:
+    resolution: {integrity: sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==}
+    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -9458,6 +9465,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## 개요
- session-user 사이의 토큰 발급 및 검사 기능을 구현했습니다.
- prisma에서는 model을 자동으로 camelCase로 바꾸는 것을 확인했습니다. 이에 따라 ERD 상의 User_Session_Token 테이블 명을 UserSessionToken으로 변경하였습니다.
(+repository에서 해당 모델을 참조할 때는 userSessionToken으로 참조합니다.(this.prisma.userSessionToken))

## 추가내용
예외처리하는 기준을 클라이언트가 토큰을 무단으로 수정, 삭제, 생성 한 경우에 대해서 처리하였습니다. 예외처리 방법은 해당 이슈에 기록해놓았습니다.

추후 예외처리가 더 필요할 경우 추가로 구현하겠습니다.
 
## 이슈
- close #37 
