### PR TITLE
feat(be): add create question and read questions api

### DIFF
--- a/apps/server/prisma/migrations/20241110160251_init/migration.sql
+++ b/apps/server/prisma/migrations/20241110160251_init/migration.sql
@@ -1,3 +1,4 @@
+-- SQLBook: Code
 /*
   Warnings:
 

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 
 import { PrismaModule } from './prisma/prisma.module';
 import { PrismaService } from './prisma/prisma.service';
+import { QuestionsModule } from './questions/questions.module';
 import { SessionsModule } from './sessions/sessions.module';
 import { SessionsAuthModule } from './sessions-auth/sessions-auth.module';
 import { UsersModule } from './users/users.module';
 @Module({
-  imports: [UsersModule, PrismaModule, SessionsModule, SessionsAuthModule, SessionsAuthModule],
+  imports: [UsersModule, PrismaModule, SessionsModule, SessionsAuthModule, SessionsAuthModule, QuestionsModule],
   controllers: [],
   providers: [PrismaService],
 })

--- a/apps/server/src/questions/dto/create-question.dto.ts
+++ b/apps/server/src/questions/dto/create-question.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateQuestionDto {
   @ApiProperty({
@@ -28,20 +28,4 @@ export class CreateQuestionDto {
   @IsString()
   @IsNotEmpty({ message: '질문 본문은 필수입니다.' })
   body: string;
-
-  @ApiProperty({
-    example: false,
-    description: '질문이 종료된 상태인지 여부',
-    required: true,
-  })
-  @IsBoolean()
-  closed: boolean;
-
-  @ApiProperty({
-    example: false,
-    description: '질문이 고정된 상태인지 여부',
-    required: true,
-  })
-  @IsBoolean()
-  pinned: boolean;
 }

--- a/apps/server/src/questions/dto/create-question.dto.ts
+++ b/apps/server/src/questions/dto/create-question.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateQuestionDto {
+  @ApiProperty({
+    example: 'user_token_123',
+    description: '질문을 작성한 사용자의 토큰',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty({ message: '작성자 토큰은 필수입니다.' })
+  create_user_token: string;
+
+  @ApiProperty({
+    example: 'session_456',
+    description: '세션 ID',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty({ message: '세션 ID는 필수입니다.' })
+  session_id: string;
+
+  @ApiProperty({
+    example: '이것은 질문의 내용입니다.',
+    description: '질문 본문 내용',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty({ message: '질문 본문은 필수입니다.' })
+  body: string;
+
+  @ApiProperty({
+    example: false,
+    description: '질문이 종료된 상태인지 여부',
+    required: true,
+  })
+  @IsBoolean()
+  closed: boolean;
+
+  @ApiProperty({
+    example: false,
+    description: '질문이 고정된 상태인지 여부',
+    required: true,
+  })
+  @IsBoolean()
+  pinned: boolean;
+}

--- a/apps/server/src/questions/dto/get-question.dto.ts
+++ b/apps/server/src/questions/dto/get-question.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+export class GetQuestionDto {
+  @ApiProperty({
+    example: '672e1c17-dcd4-8010-927c-84369a530f29',
+    description: '참여한 세션의 id',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  sessionId: string;
+
+  @ApiProperty({
+    example: '8d9a6b17-f4f6-47c2-b080-9abf792b4c76',
+    description: '세션에 참여한 사용자의 token',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  userToken: string;
+}

--- a/apps/server/src/questions/questions.controller.spec.ts
+++ b/apps/server/src/questions/questions.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { QuestionsController } from './questions.controller';
+import { QuestionsService } from './questions.service';
+
+describe('QuestionsController', () => {
+  let controller: QuestionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuestionsController],
+      providers: [QuestionsService],
+    }).compile();
+
+    controller = module.get<QuestionsController>(QuestionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/server/src/questions/questions.controller.ts
+++ b/apps/server/src/questions/questions.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Param, Post, Query, UseInterceptors } from '@nestjs/common';
+import { ApiBody, ApiTags } from '@nestjs/swagger';
+
+import { CreateQuestionDto } from './dto/create-question.dto';
+import { GetQuestionDto } from './dto/get-question.dto';
+import { QuestionsService } from './questions.service';
+import { CreateQuestionSwagger } from './swagger/create-question.swagger';
+import { GetQuestionSwagger } from './swagger/get-question.swagger';
+import { TransformInterceptor } from '../common/interceptors/transform.interceptor';
+
+@ApiTags('Questions')
+@UseInterceptors(TransformInterceptor)
+@Controller('questions')
+export class QuestionsController {
+  constructor(private readonly questionsService: QuestionsService) {}
+
+  @Post()
+  @CreateQuestionSwagger()
+  @ApiBody({ type: CreateQuestionDto })
+  async createQuestion(@Body() createQuestionDto: CreateQuestionDto) {
+    await this.questionsService.createQuestion(createQuestionDto);
+    return {};
+  }
+
+  @Get()
+  @GetQuestionSwagger()
+  async getQuestionsBySession(@Query() getQuestionDto: GetQuestionDto) {
+    const questions = await this.questionsService.getQuestionsBySession(getQuestionDto);
+    return { questions: questions };
+  }
+}

--- a/apps/server/src/questions/questions.module.ts
+++ b/apps/server/src/questions/questions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { QuestionsController } from './questions.controller';
+import { QuestionRepository } from './questions.repository';
+import { QuestionsService } from './questions.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [QuestionsController],
+  providers: [QuestionsService, QuestionRepository],
+})
+export class QuestionsModule {}

--- a/apps/server/src/questions/questions.repository.ts
+++ b/apps/server/src/questions/questions.repository.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+
+import { DatabaseException } from '../common/exceptions/resource.exception';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateQuestionDto } from './dto/create-question.dto';
+
+@Injectable()
+export class QuestionRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: CreateQuestionDto) {
+    try {
+      await this.prisma.question.create({ data });
+    } catch (error) {
+      throw DatabaseException.create('question');
+    }
+  }
+
+  async findQuestionsWithDetails(sessionId: string) {
+    try {
+      return await this.prisma.question.findMany({
+        where: { session_id: sessionId },
+        include: {
+          questionLikes: {
+            select: {
+              create_user_token: true,
+            },
+          },
+          createUserToken: {
+            select: {
+              user: {
+                select: { nickname: true },
+              },
+            },
+          },
+          replies: {
+            include: {
+              createUserToken: {
+                select: {
+                  user: {
+                    select: { nickname: true },
+                  },
+                },
+              },
+              replyLikes: {
+                select: {
+                  create_user_token: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      throw DatabaseException.read('question');
+    }
+  }
+}

--- a/apps/server/src/questions/questions.repository.ts
+++ b/apps/server/src/questions/questions.repository.ts
@@ -9,8 +9,13 @@ export class QuestionRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(data: CreateQuestionDto) {
+    const questionData = {
+      ...data,
+      pinned: false,
+      closed: false,
+    };
     try {
-      await this.prisma.question.create({ data });
+      await this.prisma.question.create({ data: questionData });
     } catch (error) {
       throw DatabaseException.create('question');
     }

--- a/apps/server/src/questions/questions.service.spec.ts
+++ b/apps/server/src/questions/questions.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { QuestionsService } from './questions.service';
+
+describe('QuestionsService', () => {
+  let service: QuestionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuestionsService],
+    }).compile();
+
+    service = module.get<QuestionsService>(QuestionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/server/src/questions/questions.service.ts
+++ b/apps/server/src/questions/questions.service.ts
@@ -11,7 +11,6 @@ export class QuestionsService {
   async createQuestion(data: CreateQuestionDto) {
     return await this.questionsRepository.create(data);
   }
-
   async getQuestionsBySession(data: GetQuestionDto) {
     const { sessionId, userToken } = data;
     const questions = await this.questionsRepository.findQuestionsWithDetails(sessionId);

--- a/apps/server/src/questions/questions.service.ts
+++ b/apps/server/src/questions/questions.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+
+import { CreateQuestionDto } from './dto/create-question.dto';
+import { GetQuestionDto } from './dto/get-question.dto';
+import { QuestionRepository } from './questions.repository';
+
+@Injectable()
+export class QuestionsService {
+  constructor(private readonly questionsRepository: QuestionRepository) {}
+
+  async createQuestion(data: CreateQuestionDto) {
+    return await this.questionsRepository.create(data);
+  }
+
+  async getQuestionsBySession(data: GetQuestionDto) {
+    const { sessionId, userToken } = data;
+    const questions = await this.questionsRepository.findQuestionsWithDetails(sessionId);
+
+    const mapLikesAndOwnership = <
+      T extends { create_user_token: string; likes: { create_user_token: string }[]; createUserToken?: { user?: { nickname?: string } } },
+    >(
+      item: T,
+      userToken: string,
+    ) => {
+      const isOwner = item.create_user_token === userToken;
+      const likesCount = item.likes.length;
+      const hasLiked = item.likes.some((like) => like.create_user_token === userToken);
+      const nickname = item.createUserToken?.user?.nickname || '익명';
+
+      return { isOwner, likesCount, hasLiked, nickname };
+    };
+
+    return questions.map((question) => {
+      const { questionLikes, replies, question_id, create_user_token, body, closed, pinned, created_at, session_id, createUserToken } = question;
+
+      const questionInfo = {
+        question_id,
+        session_id,
+        body,
+        closed,
+        pinned,
+        created_at,
+        ...mapLikesAndOwnership({ create_user_token, likes: questionLikes, createUserToken }, userToken),
+      };
+
+      const replyInfo = replies.map((reply) => {
+        const { reply_id, create_user_token, body, created_at, createUserToken, replyLikes } = reply;
+
+        return {
+          reply_id,
+          body,
+          created_at,
+          ...mapLikesAndOwnership({ create_user_token, likes: replyLikes, createUserToken }, userToken),
+        };
+      });
+
+      return {
+        ...questionInfo,
+        replies: replyInfo,
+      };
+    });
+  }
+}

--- a/apps/server/src/questions/swagger/create-question.swagger.ts
+++ b/apps/server/src/questions/swagger/create-question.swagger.ts
@@ -1,0 +1,17 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const CreateQuestionSwagger = () =>
+  applyDecorators(
+    ApiOperation({ summary: '새 질문 생성' }),
+    ApiResponse({
+      status: 201,
+      description: '질문 생성 성공',
+      schema: {
+        example: {
+          type: 'success',
+          data: {},
+        },
+      },
+    }),
+  );

--- a/apps/server/src/questions/swagger/get-question.swagger.ts
+++ b/apps/server/src/questions/swagger/get-question.swagger.ts
@@ -1,0 +1,79 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const GetQuestionSwagger = () =>
+  applyDecorators(
+    ApiOperation({ summary: '질문 정보 조회' }),
+    ApiResponse({
+      status: 200,
+      description: '질문 조회 성공',
+      schema: {
+        example: {
+          type: 'success',
+          data: {
+            questions: [
+              {
+                question_id: 1,
+                session_id: '672e1c17-dcd4-8010-927c-84369a530f29',
+                body: 'Question 1 body',
+                closed: false,
+                pinned: false,
+                created_at: '2024-11-11T16:03:39.915Z',
+                isOwner: false,
+                likesCount: 1,
+                hasLiked: true,
+                nickname: 'user1',
+                replies: [
+                  {
+                    reply_id: 1,
+                    body: 'Reply 1 to Question 1',
+                    created_at: '2024-11-11T16:04:02.532Z',
+                    isOwner: false,
+                    likesCount: 1,
+                    hasLiked: true,
+                    nickname: 'user1',
+                  },
+                ],
+              },
+              {
+                question_id: 2,
+                session_id: '672e1c17-dcd4-8010-927c-84369a530f29',
+                body: 'Question 2 body',
+                closed: false,
+                pinned: false,
+                created_at: '2024-11-11T16:03:39.915Z',
+                isOwner: true,
+                likesCount: 1,
+                hasLiked: true,
+                nickname: '익명',
+                replies: [
+                  {
+                    reply_id: 2,
+                    body: 'Reply 2 to Question 2',
+                    created_at: '2024-11-11T16:04:02.532Z',
+                    isOwner: true,
+                    likesCount: 1,
+                    hasLiked: true,
+                    nickname: '익명',
+                  },
+                ],
+              },
+              {
+                question_id: 3,
+                session_id: '672e1c17-dcd4-8010-927c-84369a530f29',
+                body: 'Question 3 body',
+                closed: false,
+                pinned: false,
+                created_at: '2024-11-11T16:03:39.915Z',
+                isOwner: true,
+                likesCount: 1,
+                hasLiked: true,
+                nickname: '익명',
+                replies: [],
+              },
+            ],
+          },
+        },
+      },
+    }),
+  );


### PR DESCRIPTION
## 개요
- 렌더링에 필요한 세션에 맞는 디테일을 가진 질문 데이터를 가져오는 GET API를 만들었습니다.
- 사용자가 질문을 생성하기 위한 POST API를 만들었습니다.

## 이슈

- close #59 
