### PR TITLE
feat(fe): integrate session API

### DIFF
--- a/apps/client/.eslintrc.json
+++ b/apps/client/.eslintrc.json
@@ -27,12 +27,6 @@
       },
       "plugins": ["react-hooks", "react-refresh"],
       "rules": {
-        "camelcase": [
-          "error",
-          {
-            "ignoreDestructuring": true
-          }
-        ],
         "react/react-in-jsx-scope": "off",
         "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",

--- a/apps/client/src/components/Header.tsx
+++ b/apps/client/src/components/Header.tsx
@@ -23,6 +23,7 @@ function Header() {
   const handleLogout = () =>
     logout().then(() => {
       clearAccessToken();
+      navigate({ to: '/' });
       addToast({
         type: 'SUCCESS',
         message: '로그아웃 되었습니다.',

--- a/apps/client/src/components/modal/CreateSessionModal.tsx
+++ b/apps/client/src/components/modal/CreateSessionModal.tsx
@@ -1,14 +1,36 @@
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import Button from '@/components/Button';
 import InputField from '@/components/modal/InputField';
 import Modal from '@/components/modal/Modal';
 import { useModalContext } from '@/features/modal';
+import { createSession } from '@/features/session/session.api';
+import { useToastStore } from '@/features/toast';
 
 function CreateSessionModal() {
+  const addToast = useToastStore((state) => state.addToast);
+
   const { closeModal } = useModalContext();
 
   const [sessionName, setSessionName] = useState('');
+
+  const navigate = useNavigate();
+
+  const handleCreateSession = () =>
+    sessionName.length > 0 &&
+    createSession({ title: sessionName }).then((res) => {
+      closeModal();
+      addToast({
+        type: 'SUCCESS',
+        message: `세션( ${sessionName} )이 생성되었습니다.`,
+        duration: 3000,
+      });
+      navigate({
+        to: '/session/$sessionId',
+        params: { sessionId: res.data.sessionId },
+      });
+    });
 
   return (
     <Modal>
@@ -23,13 +45,7 @@ function CreateSessionModal() {
         />
       </div>
       <div className='mt-4 inline-flex items-start justify-start gap-2.5'>
-        <Button
-          className='bg-indigo-600'
-          onClick={() => {
-            // TODO: 세션 생성 API 요청 후, 세션 화면으로 이동
-            closeModal();
-          }}
-        >
+        <Button className='bg-indigo-600' onClick={handleCreateSession}>
           <div className='w-[150px] text-sm font-medium text-white'>
             세션 생성하기
           </div>

--- a/apps/client/src/components/modal/CreateSessionModal.tsx
+++ b/apps/client/src/components/modal/CreateSessionModal.tsx
@@ -18,7 +18,7 @@ function CreateSessionModal() {
   const navigate = useNavigate();
 
   const handleCreateSession = () =>
-    sessionName.length > 0 &&
+    sessionName.trim().length > 0 &&
     createSession({ title: sessionName }).then((res) => {
       closeModal();
       addToast({
@@ -45,7 +45,10 @@ function CreateSessionModal() {
         />
       </div>
       <div className='mt-4 inline-flex items-start justify-start gap-2.5'>
-        <Button className='bg-indigo-600' onClick={handleCreateSession}>
+        <Button
+          className={`transition-colors duration-200 ${sessionName.trim().length > 0 ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
+          onClick={handleCreateSession}
+        >
           <div className='w-[150px] text-sm font-medium text-white'>
             세션 생성하기
           </div>

--- a/apps/client/src/components/my/SessionRecord.tsx
+++ b/apps/client/src/components/my/SessionRecord.tsx
@@ -3,12 +3,18 @@ import { Link } from '@tanstack/react-router';
 import { formatDate } from '@/shared';
 
 interface SessionRecordProps {
+  sessionId: string;
   sessionName: string;
   closed: boolean;
   createdAt: Date;
 }
 
-function SessionRecord({ sessionName, createdAt, closed }: SessionRecordProps) {
+function SessionRecord({
+  sessionId,
+  sessionName,
+  createdAt,
+  closed,
+}: SessionRecordProps) {
   return (
     <div className='flex h-fit flex-col items-start justify-start gap-4 self-stretch border-b border-gray-200 px-2.5 pb-4 pt-2.5'>
       <div className='flex h-fit flex-col items-start justify-center gap-2.5 self-stretch'>
@@ -27,10 +33,7 @@ function SessionRecord({ sessionName, createdAt, closed }: SessionRecordProps) {
         )}
       </div>
       <div className='inline-flex items-start justify-between self-stretch px-1'>
-        <Link
-          to='/session/$sessionId'
-          params={{ sessionId: 'hello-session-1' }}
-        >
+        <Link to='/session/$sessionId' params={{ sessionId }}>
           <div className='text-base font-medium leading-normal text-black'>
             {sessionName}
           </div>

--- a/apps/client/src/features/auth/auth.store.ts
+++ b/apps/client/src/features/auth/auth.store.ts
@@ -1,7 +1,5 @@
 import { create } from 'zustand';
 
-import { refresh } from '@/features/auth/auth.api';
-
 interface AuthStore {
   accessToken: string | null;
   isLogin: () => boolean;
@@ -15,8 +13,3 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   setAccessToken: (accessToken) => set({ accessToken }),
   clearAccessToken: () => set({ accessToken: null }),
 }));
-
-refresh().then((res) => {
-  if (res.type === 'success')
-    useAuthStore.getState().setAccessToken(res.data.accessToken);
-});

--- a/apps/client/src/features/session/index.ts
+++ b/apps/client/src/features/session/index.ts
@@ -1,1 +1,2 @@
 export * from './session.store';
+export * from './session.api';

--- a/apps/client/src/features/session/session.api.ts
+++ b/apps/client/src/features/session/session.api.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+import {
+  CreateSessionRequestDTO,
+  CreateSessionResponseDTO,
+  GetSessionsResponseDTO,
+} from '@/features/session/session.dto';
+
+export const createSession = (
+  createSessionRequestDTO: CreateSessionRequestDTO,
+) =>
+  axios
+    .post<CreateSessionResponseDTO>('/api/sessions', createSessionRequestDTO)
+    .then((res) => res.data);
+
+export const getSessions = () =>
+  axios.get<GetSessionsResponseDTO>('/api/sessions').then((res) => res.data);
+
+export const getSessionToken = (sessionId: string, token?: string) =>
+  axios
+    .get(`/api/sessions-auth`, {
+      params: {
+        session_id: sessionId,
+        token,
+      },
+    })
+    .then((res) => res.data);

--- a/apps/client/src/features/session/session.api.ts
+++ b/apps/client/src/features/session/session.api.ts
@@ -4,6 +4,7 @@ import {
   CreateSessionRequestDTO,
   CreateSessionResponseDTO,
   GetSessionsResponseDTO,
+  GetSessionTokenResponseDTO,
 } from '@/features/session/session.dto';
 
 export const createSession = (
@@ -16,12 +17,26 @@ export const createSession = (
 export const getSessions = () =>
   axios.get<GetSessionsResponseDTO>('/api/sessions').then((res) => res.data);
 
-export const getSessionToken = (sessionId: string, token?: string) =>
-  axios
-    .get(`/api/sessions-auth`, {
+export const getSessionToken = (sessionId: string) => {
+  const tokens = JSON.parse(
+    localStorage.getItem('sessionTokens') || '{}',
+  ) as Record<string, string>;
+
+  const token = tokens[sessionId];
+
+  return axios
+    .get<GetSessionTokenResponseDTO>(`/api/sessions-auth`, {
       params: {
         session_id: sessionId,
         token,
       },
     })
-    .then((res) => res.data);
+    .then((res) => res.data)
+    .then((data) => {
+      localStorage.setItem(
+        'sessionTokens',
+        JSON.stringify({ ...tokens, [sessionId]: data.data.token }),
+      );
+      return data;
+    });
+};

--- a/apps/client/src/features/session/session.dto.ts
+++ b/apps/client/src/features/session/session.dto.ts
@@ -1,0 +1,26 @@
+import { SuccessDTO } from '@/shared';
+
+export interface CreateSessionRequestDTO {
+  title: string;
+}
+
+export type CreateSessionResponseDTO = SuccessDTO<{
+  sessionId: string;
+}>;
+
+export type GetSessionsResponseDTO = SuccessDTO<{
+  sessionData: Array<{
+    session_id: string;
+    title: string;
+    create_at: {
+      year: number;
+      month: number;
+      day: number;
+    };
+    expired: boolean;
+  }>;
+}>;
+
+export type GetSessionTokenResponseDTO = SuccessDTO<{
+  token: string;
+}>;

--- a/apps/client/src/features/session/session.dto.ts
+++ b/apps/client/src/features/session/session.dto.ts
@@ -12,10 +12,10 @@ export type GetSessionsResponseDTO = SuccessDTO<{
   sessionData: Array<{
     session_id: string;
     title: string;
-    create_at: {
+    created_at: {
       year: number;
       month: number;
-      day: number;
+      date: number;
     };
     expired: boolean;
   }>;

--- a/apps/client/src/pages/MyPage.tsx
+++ b/apps/client/src/pages/MyPage.tsx
@@ -25,7 +25,7 @@ function MyPage() {
               createdAt={
                 new Date(
                   session.created_at.year,
-                  session.created_at.month,
+                  session.created_at.month - 1,
                   session.created_at.date,
                 )
               }

--- a/apps/client/src/pages/MyPage.tsx
+++ b/apps/client/src/pages/MyPage.tsx
@@ -11,11 +11,11 @@ function MyPage() {
   return (
     <div className='inline-flex h-full w-full items-center justify-center gap-4 overflow-hidden px-4 py-4 md:max-w-[1194px]'>
       <div className='inline-flex shrink grow basis-0 flex-col items-center justify-start gap-4 self-stretch rounded-lg bg-white shadow'>
-        <div className='inline-flex items-center justify-between self-stretch border-b border-gray-200 px-8 py-2'>
+        <div className='inline-flex h-[54px] items-center justify-between self-stretch border-b border-gray-200 px-8 py-2'>
           <div className='text-lg font-medium text-black'>참여한 세션 기록</div>
           <div className='rounded-md px-3 py-2' />
         </div>
-        <div className='flex shrink grow basis-0 flex-col items-start justify-start gap-4 self-stretch overflow-y-auto px-8 pb-4'>
+        <div className='flex shrink grow basis-0 flex-col items-start justify-start gap-4 self-stretch overflow-y-auto px-8 py-2'>
           {sessions?.map((session) => (
             <SessionRecord
               key={session.session_id}

--- a/apps/client/src/pages/MyPage.tsx
+++ b/apps/client/src/pages/MyPage.tsx
@@ -1,6 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
 import { SessionRecord } from '@/components/my';
+import { getSessions } from '@/features/session';
 
 function MyPage() {
+  const { data } = useQuery({ queryKey: ['/sessions'], queryFn: getSessions });
+
+  const sessions = data?.data.sessionData;
+
   return (
     <div className='inline-flex h-full w-full items-center justify-center gap-4 overflow-hidden px-4 py-4 md:max-w-[1194px]'>
       <div className='inline-flex shrink grow basis-0 flex-col items-center justify-start gap-4 self-stretch rounded-lg bg-white shadow'>
@@ -9,16 +16,21 @@ function MyPage() {
           <div className='rounded-md px-3 py-2' />
         </div>
         <div className='flex shrink grow basis-0 flex-col items-start justify-start gap-4 self-stretch overflow-y-auto px-8 pb-4'>
-          <SessionRecord
-            sessionName='못말리는 장난꾸러기의 세션'
-            createdAt={new Date()}
-            closed
-          />
-          <SessionRecord
-            sessionName='못말리는 장난꾸러기의 세션'
-            createdAt={new Date()}
-            closed={false}
-          />
+          {sessions?.map((session) => (
+            <SessionRecord
+              key={session.session_id}
+              sessionId={session.session_id}
+              sessionName={session.title}
+              closed={session.expired}
+              createdAt={
+                new Date(
+                  session.created_at.year,
+                  session.created_at.month,
+                  session.created_at.date,
+                )
+              }
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/apps/client/src/pages/QnAPage.tsx
+++ b/apps/client/src/pages/QnAPage.tsx
@@ -1,7 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 
 import { ChattingList } from '@/components';
 import QuestionContent from '@/components/qna/QuestionContent';
+import { getSessionToken } from '@/features/session';
 import { QnAContextProvider } from '@/features/session/qna';
 
 function QnAPage() {
@@ -11,7 +13,12 @@ function QnAPage() {
     strict: true,
   });
 
-  console.log(sessionId);
+  const { data: token } = useQuery({
+    queryKey: ['/sessions-auth', sessionId],
+    queryFn: () => getSessionToken(sessionId),
+  });
+
+  console.log(token);
 
   return (
     <div className='flex h-full w-full items-center justify-center gap-4 px-4 py-4 md:max-w-[1194px]'>

--- a/apps/client/src/pages/QnAPage.tsx
+++ b/apps/client/src/pages/QnAPage.tsx
@@ -1,9 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 
 import { ChattingList } from '@/components';
 import QuestionContent from '@/components/qna/QuestionContent';
-import { getSessionToken } from '@/features/session';
 import { QnAContextProvider } from '@/features/session/qna';
 
 function QnAPage() {
@@ -13,12 +11,7 @@ function QnAPage() {
     strict: true,
   });
 
-  const { data: token } = useQuery({
-    queryKey: ['/sessions-auth', sessionId],
-    queryFn: () => getSessionToken(sessionId),
-  });
-
-  console.log(token);
+  console.log(sessionId);
 
   return (
     <div className='flex h-full w-full items-center justify-center gap-4 px-4 py-4 md:max-w-[1194px]'>

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -1,9 +1,16 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 
 import { Header } from '@/components';
+import { refresh, useAuthStore } from '@/features/auth';
 import { ToastContainer } from '@/features/toast';
 
 export const Route = createRootRoute({
+  beforeLoad: async () => {
+    refresh().then((res) => {
+      if (res.type === 'success')
+        useAuthStore.getState().setAccessToken(res.data.accessToken);
+    });
+  },
   component: () => (
     <div className='flex h-dvh w-dvw min-w-[390px] flex-col bg-gray-50'>
       <Header />

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -6,10 +6,11 @@ import { ToastContainer } from '@/features/toast';
 
 export const Route = createRootRoute({
   beforeLoad: async () => {
-    refresh().then((res) => {
-      if (res.type === 'success')
-        useAuthStore.getState().setAccessToken(res.data.accessToken);
-    });
+    if (!useAuthStore.getState().isLogin())
+      refresh().then((res) => {
+        if (res.type === 'success')
+          useAuthStore.getState().setAccessToken(res.data.accessToken);
+      });
   },
   component: () => (
     <div className='flex h-dvh w-dvw min-w-[390px] flex-col bg-gray-50'>

--- a/apps/client/src/routes/my.tsx
+++ b/apps/client/src/routes/my.tsx
@@ -1,7 +1,15 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
+import { useAuthStore } from '@/features/auth';
 import { MyPage } from '@/pages';
 
 export const Route = createFileRoute('/my')({
   component: MyPage,
+  beforeLoad: async () => {
+    const { accessToken } = useAuthStore.getState();
+    if (!accessToken) {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw redirect({ to: '/' });
+    }
+  },
 });

--- a/apps/client/src/routes/my.tsx
+++ b/apps/client/src/routes/my.tsx
@@ -6,8 +6,7 @@ import { MyPage } from '@/pages';
 export const Route = createFileRoute('/my')({
   component: MyPage,
   beforeLoad: async () => {
-    const { accessToken } = useAuthStore.getState();
-    if (!accessToken) {
+    if (!useAuthStore.getState().isLogin()) {
       // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw redirect({ to: '/' });
     }

--- a/apps/client/src/routes/session.$sessionId.tsx
+++ b/apps/client/src/routes/session.$sessionId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import { getSessionToken } from '@/features/session';
 import { QnAPage } from '@/pages';
 
 export const Route = createFileRoute('/session/$sessionId')({
@@ -9,6 +10,6 @@ export const Route = createFileRoute('/session/$sessionId')({
      * TODO
      * 여기에서 데이터를 가져오고 전역상태로 데이터 이전
      */
-    console.log(sessionId);
+    getSessionToken(sessionId);
   },
 });

--- a/apps/client/src/routes/session.$sessionId.tsx
+++ b/apps/client/src/routes/session.$sessionId.tsx
@@ -4,4 +4,11 @@ import { QnAPage } from '@/pages';
 
 export const Route = createFileRoute('/session/$sessionId')({
   component: QnAPage,
+  beforeLoad: async ({ params: { sessionId } }) => {
+    /**
+     * TODO
+     * 여기에서 데이터를 가져오고 전역상태로 데이터 이전
+     */
+    console.log(sessionId);
+  },
 });


### PR DESCRIPTION
## 개요

- 세션과 관련된 API 연동 작업을 진행했습니다.
- 세션 생성 후 해당 세션으로 이동합니다.
  - 비어있는 세션 이름으론 생성할 수 없습니다.
- 마이페이지에서 참여한 세션을 조회할 수 있습니다.
  - 비 로그인 상태에서 마이페이지로 접속하면 메인 페이지로 리다이렉트합니다.
  - 참여한 세션을 클릭하면 해당 세션으로 접속합니다.
- Q&A 세션에 접속하면 세션 토큰 발급 API를 통해 세션에 맞는 토큰을 가져옵니다.
  - 토큰 발급 API 내부에서 스토리지로부터 불러오기, 저장 로직을 추가합니다.
- 페이지 로딩 전, 로그인 여부를 판단하고 렌더링을 진행하는 방식으로 변경했습니다.

## 이슈

- close #111 
