### PR TITLE
fix(be): return only the token from new user session creation

### DIFF
--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -17,7 +17,7 @@ export class SessionsAuthRepository {
         token: uuid4(),
       },
     });
-    return newUserSessionToken;
+    return newUserSessionToken.token;
   }
 
   async findTokenByUserId(user_id: number, session_id: string) {


### PR DESCRIPTION
## 개요

- 일관되지 않은 반환 값을 수정했습니다.

## 간단해서 없슈
