### PR TITLE
feat(fe): prevent duplicate api requests

### DIFF
--- a/apps/client/src/components/modal/CreateQuestionModal.tsx
+++ b/apps/client/src/components/modal/CreateQuestionModal.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 
@@ -27,16 +28,10 @@ function CreateQuestionModal({ question }: CreateQuestionModalProps) {
 
   const [body, setBody] = useState('');
 
-  const handleSubmit = () => {
-    if (expired || body.trim().length === 0 || !sessionId || !sessionToken)
-      return;
-
-    if (!question) {
-      postQuestion({
-        token: sessionToken,
-        sessionId,
-        body,
-      }).then((response) => {
+  const { mutate: postQuestionQuery, isPending: isPostInProgress } =
+    useMutation({
+      mutationFn: postQuestion,
+      onSuccess: (response) => {
         addQuestion(response.question);
         addToast({
           type: 'SUCCESS',
@@ -44,13 +39,23 @@ function CreateQuestionModal({ question }: CreateQuestionModalProps) {
           duration: 3000,
         });
         closeModal();
-      });
-    } else {
-      patchQuestionBody(question.questionId, {
-        token: sessionToken,
-        sessionId,
-        body,
-      }).then((response) => {
+      },
+    });
+
+  const { mutate: patchQuestionBodyQuery, isPending: isPatchInProgress } =
+    useMutation({
+      mutationFn: (params: {
+        questionId: number;
+        token: string;
+        sessionId: string;
+        body: string;
+      }) =>
+        patchQuestionBody(params.questionId, {
+          token: params.token,
+          sessionId: params.sessionId,
+          body: params.body,
+        }),
+      onSuccess: (response) => {
         updateQuestion(response.question);
         addToast({
           type: 'SUCCESS',
@@ -58,6 +63,32 @@ function CreateQuestionModal({ question }: CreateQuestionModalProps) {
           duration: 3000,
         });
         closeModal();
+      },
+    });
+
+  const submitDisabled =
+    expired ||
+    body.trim().length === 0 ||
+    !sessionId ||
+    !sessionToken ||
+    isPostInProgress ||
+    isPatchInProgress;
+
+  const handleSubmit = () => {
+    if (submitDisabled) return;
+
+    if (!question) {
+      postQuestionQuery({
+        token: sessionToken,
+        sessionId,
+        body,
+      });
+    } else {
+      patchQuestionBodyQuery({
+        questionId: question.questionId,
+        token: sessionToken,
+        sessionId,
+        body,
       });
     }
   };
@@ -89,7 +120,10 @@ function CreateQuestionModal({ question }: CreateQuestionModalProps) {
         </div>
         <div className='flex h-fit flex-col items-end justify-center gap-2.5 self-stretch'>
           <div className='inline-flex items-center justify-center gap-2.5'>
-            <Button className='bg-indigo-600' onClick={handleSubmit}>
+            <Button
+              className={`${!submitDisabled ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
+              onClick={handleSubmit}
+            >
               <div className='text-sm font-bold text-white'>
                 {question ? '수정하기' : '생성하기'}
               </div>

--- a/apps/client/src/components/modal/CreateReplyModal.tsx
+++ b/apps/client/src/components/modal/CreateReplyModal.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 
@@ -29,16 +30,10 @@ function CreateReplyModal({ question, reply }: CreateReplyModalProps) {
 
   const [body, setBody] = useState('');
 
-  const handleSubmit = () => {
-    if (expired || !sessionId || !sessionToken) return;
-
-    if (!reply && question) {
-      postReply({
-        sessionId,
-        token: sessionToken,
-        questionId: question?.questionId,
-        body,
-      }).then((res) => {
+  const { mutate: postReplyQuery, isPending: isPostInProgress } = useMutation({
+    mutationFn: postReply,
+    onSuccess: (res) => {
+      if (!reply && question) {
         addReply(question.questionId, { ...res.reply, deleted: false });
         addToast({
           type: 'SUCCESS',
@@ -46,20 +41,60 @@ function CreateReplyModal({ question, reply }: CreateReplyModalProps) {
           duration: 3000,
         });
         closeModal();
+      }
+    },
+  });
+
+  const { mutate: patchReplyBodyQuery, isPending: isPatchInProgress } =
+    useMutation({
+      mutationFn: (params: {
+        replyId: number;
+        token: string;
+        sessionId: string;
+        body: string;
+      }) =>
+        patchReplyBody(params.replyId, {
+          token: params.token,
+          sessionId: params.sessionId,
+          body: params.body,
+        }),
+      onSuccess: (res) => {
+        if (reply && question) {
+          updateReply(question.questionId, res.reply);
+          addToast({
+            type: 'SUCCESS',
+            message: '답변이 성공적으로 수정되었습니다.',
+            duration: 3000,
+          });
+          closeModal();
+        }
+      },
+    });
+
+  const submitDisabled =
+    expired ||
+    body.trim().length === 0 ||
+    !sessionId ||
+    !sessionToken ||
+    isPostInProgress ||
+    isPatchInProgress;
+
+  const handleSubmit = () => {
+    if (submitDisabled) return;
+
+    if (!reply && question) {
+      postReplyQuery({
+        sessionId,
+        token: sessionToken,
+        questionId: question?.questionId,
+        body,
       });
     } else if (reply && question) {
-      patchReplyBody(reply.replyId, {
+      patchReplyBodyQuery({
+        replyId: reply.replyId,
         token: sessionToken,
         sessionId,
         body,
-      }).then((res) => {
-        updateReply(question.questionId, res.reply);
-        addToast({
-          type: 'SUCCESS',
-          message: '답변이 성공적으로 수정되었습니다.',
-          duration: 3000,
-        });
-        closeModal();
       });
     }
   };
@@ -91,7 +126,10 @@ function CreateReplyModal({ question, reply }: CreateReplyModalProps) {
         </div>
         <div className='flex h-fit flex-col items-end justify-center gap-2.5 self-stretch'>
           <div className='inline-flex items-center justify-center gap-2.5'>
-            <Button className='bg-indigo-600' onClick={handleSubmit}>
+            <Button
+              className={`${!submitDisabled ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
+              onClick={handleSubmit}
+            >
               <div className='text-sm font-bold text-white'>
                 {reply ? '수정하기' : '생성하기'}
               </div>

--- a/apps/client/src/components/modal/CreateSessionModal.tsx
+++ b/apps/client/src/components/modal/CreateSessionModal.tsx
@@ -36,7 +36,7 @@ function CreateSessionModal() {
   });
 
   const enableCreateSession =
-    sessionName.trim().length > 3 && sessionName.trim().length <= 20;
+    sessionName.trim().length >= 3 && sessionName.trim().length <= 20;
 
   const handleCreateSession = () => {
     if (!enableCreateSession || isPending) return;

--- a/apps/client/src/components/modal/CreateSessionModal.tsx
+++ b/apps/client/src/components/modal/CreateSessionModal.tsx
@@ -19,7 +19,7 @@ function CreateSessionModal() {
 
   const navigate = useNavigate();
 
-  const { mutate, isPending } = useMutation({
+  const { mutate: postSessionQuery, isPending } = useMutation({
     mutationFn: postSession,
     onSuccess: (res) => {
       closeModal();
@@ -40,7 +40,7 @@ function CreateSessionModal() {
 
   const handleCreateSession = () => {
     if (!enableCreateSession || isPending) return;
-    mutate({ title: sessionName });
+    postSessionQuery({ title: sessionName });
   };
 
   return (

--- a/apps/client/src/components/modal/CreateSessionModal.tsx
+++ b/apps/client/src/components/modal/CreateSessionModal.tsx
@@ -36,7 +36,7 @@ function CreateSessionModal() {
   });
 
   const enableCreateSession =
-    sessionName.trim().length > 0 && sessionName.trim().length <= 2;
+    sessionName.trim().length > 3 && sessionName.trim().length <= 20;
 
   const handleCreateSession = () => {
     if (!enableCreateSession || isPending) return;

--- a/apps/client/src/components/modal/CreateSessionModal.tsx
+++ b/apps/client/src/components/modal/CreateSessionModal.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
@@ -18,23 +19,29 @@ function CreateSessionModal() {
 
   const navigate = useNavigate();
 
-  const enableCreateSession =
-    sessionName.trim().length > 0 && sessionName.trim().length <= 20;
-
-  const handleCreateSession = () =>
-    enableCreateSession &&
-    postSession({ title: sessionName }).then((res) => {
+  const { mutate, isPending } = useMutation({
+    mutationFn: postSession,
+    onSuccess: (res) => {
       closeModal();
       addToast({
         type: 'SUCCESS',
-        message: `세션( ${sessionName} )이 생성되었습니다.`,
+        message: `세션(${sessionName})이 생성되었습니다.`,
         duration: 3000,
       });
       navigate({
         to: '/session/$sessionId',
         params: { sessionId: res.sessionId },
       });
-    });
+    },
+  });
+
+  const enableCreateSession =
+    sessionName.trim().length > 0 && sessionName.trim().length <= 2;
+
+  const handleCreateSession = () => {
+    if (!enableCreateSession || isPending) return;
+    mutate({ title: sessionName });
+  };
 
   return (
     <Modal>

--- a/apps/client/src/components/modal/SignInModal.tsx
+++ b/apps/client/src/components/modal/SignInModal.tsx
@@ -20,7 +20,7 @@ function SignInModal() {
   } = useSignInForm();
 
   const login = () => {
-    handleLogin(() => closeModal());
+    if (isLoginEnabled) handleLogin(() => closeModal());
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/apps/client/src/components/modal/SignInModal.tsx
+++ b/apps/client/src/components/modal/SignInModal.tsx
@@ -1,6 +1,5 @@
 import { useSignInForm } from '@/features/auth';
 import { useModalContext } from '@/features/modal';
-import { useToastStore } from '@/features/toast';
 
 import Button from '../Button';
 
@@ -8,8 +7,6 @@ import InputField from '@/components/modal/InputField';
 import Modal from '@/components/modal/Modal';
 
 function SignInModal() {
-  const addToast = useToastStore((state) => state.addToast);
-
   const { closeModal } = useModalContext();
 
   const {
@@ -22,16 +19,9 @@ function SignInModal() {
     loginFailed,
   } = useSignInForm();
 
-  const login = () =>
-    isLoginEnabled &&
-    handleLogin().then(() => {
-      closeModal();
-      addToast({
-        type: 'SUCCESS',
-        message: '로그인 되었습니다.',
-        duration: 3000,
-      });
-    });
+  const login = () => {
+    handleLogin(() => closeModal());
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {

--- a/apps/client/src/components/modal/SignUpModal.tsx
+++ b/apps/client/src/components/modal/SignUpModal.tsx
@@ -48,7 +48,7 @@ function SignUpModal() {
   });
 
   const handleSignUp = () => {
-    if (!isSignUpEnabled) return;
+    if (!isSignUpEnabled || isPending) return;
     signUp();
   };
 

--- a/apps/client/src/components/modal/SignUpModal.tsx
+++ b/apps/client/src/components/modal/SignUpModal.tsx
@@ -1,3 +1,5 @@
+import { useMutation } from '@tanstack/react-query';
+
 import { useModalContext } from '@/features/modal';
 import { useToastStore } from '@/features/toast';
 import { postUser, useSignUpForm } from '@/features/user';
@@ -25,16 +27,32 @@ function SignUpModal() {
     isSignUpEnabled,
   } = useSignUpForm();
 
-  const signUp = () =>
-    isSignUpEnabled &&
-    postUser({ email, nickname, password }).then(() => {
+  const { mutate: signUp, isPending } = useMutation({
+    mutationFn: () => postUser({ email, nickname, password }),
+    onSuccess: () => {
       closeModal();
       addToast({
         type: 'SUCCESS',
         message: '회원가입 되었습니다.',
         duration: 3000,
       });
-    });
+    },
+    onError: () => {
+      closeModal();
+      addToast({
+        type: 'ERROR',
+        message: '회원가입에 실패했습니다.',
+        duration: 3000,
+      });
+    },
+  });
+
+  const handleSignUp = () => {
+    if (!isSignUpEnabled) return;
+    signUp();
+  };
+
+  const isSignUpButtonEnabled = isSignUpEnabled && !isPending;
 
   return (
     <Modal>
@@ -66,8 +84,8 @@ function SignUpModal() {
         />
         <div className='mt-4 inline-flex items-start justify-start gap-2.5'>
           <Button
-            className={`transition-colors duration-200 ${isSignUpEnabled ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
-            onClick={signUp}
+            className={`transition-colors duration-200 ${isSignUpButtonEnabled ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
+            onClick={handleSignUp}
           >
             <div className='w-[150px] text-sm font-medium text-white'>
               회원 가입

--- a/apps/client/src/components/modal/SignUpModal.tsx
+++ b/apps/client/src/components/modal/SignUpModal.tsx
@@ -27,7 +27,7 @@ function SignUpModal() {
     isSignUpEnabled,
   } = useSignUpForm();
 
-  const { mutate: signUp, isPending } = useMutation({
+  const { mutate: signUpQuery, isPending } = useMutation({
     mutationFn: () => postUser({ email, nickname, password }),
     onSuccess: () => {
       closeModal();
@@ -49,7 +49,7 @@ function SignUpModal() {
 
   const handleSignUp = () => {
     if (!isSignUpEnabled || isPending) return;
-    signUp();
+    signUpQuery();
   };
 
   const isSignUpButtonEnabled = isSignUpEnabled && !isPending;

--- a/apps/client/src/components/qna/QuestionItem.tsx
+++ b/apps/client/src/components/qna/QuestionItem.tsx
@@ -1,5 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+import { throttle } from 'es-toolkit';
+import { useCallback } from 'react';
 import { FiEdit2 } from 'react-icons/fi';
 import { GoCheck } from 'react-icons/go';
 import { GrClose, GrLike, GrLikeFill, GrPin } from 'react-icons/gr';
@@ -79,15 +81,22 @@ function QuestionItem({ question, onQuestionSelect }: QuestionItemProps) {
       },
     });
 
-  const handleLike = () => {
-    if (expired || !sessionToken || !sessionId || isLikeInProgress) return;
+  const handleLike = useCallback(
+    throttle(
+      () => {
+        if (expired || !sessionToken || !sessionId || isLikeInProgress) return;
 
-    likeQuestionQuery({
-      questionId: question.questionId,
-      token: sessionToken,
-      sessionId,
-    });
-  };
+        likeQuestionQuery({
+          questionId: question.questionId,
+          token: sessionToken,
+          sessionId,
+        });
+      },
+      1000,
+      { edges: ['leading'] },
+    ),
+    [],
+  );
 
   const { mutate: closeQuestionQuery, isPending: isCloseInProgress } =
     useMutation({

--- a/apps/client/src/components/qna/QuestionItem.tsx
+++ b/apps/client/src/components/qna/QuestionItem.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { FiEdit2 } from 'react-icons/fi';
 import { GoCheck } from 'react-icons/go';
@@ -52,57 +53,95 @@ function QuestionItem({ question, onQuestionSelect }: QuestionItemProps) {
     });
   };
 
-  const handleLike = () => {
-    if (expired || !sessionToken || !sessionId) return;
+  const { mutate: likeQuestionQuery, isPending: isLikeInProgress } =
+    useMutation({
+      mutationFn: (params: {
+        questionId: number;
+        token: string;
+        sessionId: string;
+      }) =>
+        postQuestionLike(params.questionId, {
+          token: params.token,
+          sessionId: params.sessionId,
+        }),
+      onSuccess: (res) => {
+        addToast({
+          type: 'SUCCESS',
+          message: question.liked
+            ? '좋아요를 취소했습니다.'
+            : '질문에 좋아요를 눌렀습니다.',
+          duration: 3000,
+        });
+        updateQuestion({
+          ...question,
+          ...res,
+        });
+      },
+    });
 
-    postQuestionLike(question.questionId, {
+  const handleLike = () => {
+    if (expired || !sessionToken || !sessionId || isLikeInProgress) return;
+
+    likeQuestionQuery({
+      questionId: question.questionId,
       token: sessionToken,
       sessionId,
-    }).then((res) => {
-      addToast({
-        type: 'SUCCESS',
-        message: question.liked
-          ? '좋아요를 취소했습니다.'
-          : '질문에 좋아요를 눌렀습니다.',
-        duration: 3000,
-      });
-      updateQuestion({
-        ...question,
-        ...res,
-      });
     });
   };
 
-  const handleClose = () => {
-    if (expired || !sessionToken || !sessionId || !isHost) return;
+  const { mutate: closeQuestionQuery, isPending: isCloseInProgress } =
+    useMutation({
+      mutationFn: (params: {
+        questionId: number;
+        token: string;
+        sessionId: string;
+        closed: boolean;
+      }) =>
+        patchQuestionClosed(params.questionId, {
+          token: params.token,
+          sessionId: params.sessionId,
+          closed: params.closed,
+        }),
+      onSuccess: () => {
+        addToast({
+          type: 'SUCCESS',
+          message: question.closed
+            ? '질문 답변 완료를 취소했습니다.'
+            : '질문을 답변 완료했습니다.',
+          duration: 3000,
+        });
+        updateQuestion({
+          ...question,
+          closed: !question.closed,
+        });
+      },
+    });
 
-    patchQuestionClosed(question.questionId, {
+  const handleClose = () => {
+    if (expired || !sessionToken || !sessionId || !isHost || isCloseInProgress)
+      return;
+
+    closeQuestionQuery({
+      questionId: question.questionId,
       token: sessionToken,
       sessionId,
       closed: !question.closed,
-    }).then(() => {
-      addToast({
-        type: 'SUCCESS',
-        message: question.closed
-          ? '질문 답변 완료를 취소했습니다.'
-          : '질문을 답변 완료했습니다.',
-        duration: 3000,
-      });
-      updateQuestion({
-        ...question,
-        closed: !question.closed,
-      });
     });
   };
 
-  const handlePin = () => {
-    if (expired || !sessionToken || !sessionId || !isHost) return;
-
-    patchQuestionPinned(question.questionId, {
-      token: sessionToken,
-      sessionId,
-      pinned: !question.pinned,
-    }).then(() => {
+  const { mutate: pinQuestionQuery, isPending: isPinInProgress } = useMutation({
+    mutationFn: (params: {
+      questionId: number;
+      token: string;
+      sessionId: string;
+      pinned: boolean;
+    }) =>
+      patchQuestionPinned(params.questionId, {
+        token: params.token,
+        sessionId: params.sessionId,
+        pinned: params.pinned,
+      }),
+    onSuccess: () => {
       addToast({
         type: 'SUCCESS',
         message: question.pinned
@@ -114,22 +153,49 @@ function QuestionItem({ question, onQuestionSelect }: QuestionItemProps) {
         ...question,
         pinned: !question.pinned,
       });
+    },
+  });
+
+  const handlePin = () => {
+    if (expired || !sessionToken || !sessionId || !isHost || isPinInProgress)
+      return;
+
+    pinQuestionQuery({
+      questionId: question.questionId,
+      token: sessionToken,
+      sessionId,
+      pinned: !question.pinned,
     });
   };
 
-  const handleDelete = () => {
-    if (expired || !sessionToken || !sessionId) return;
+  const { mutate: deleteQuestionQuery, isPending: isDeleteInProgress } =
+    useMutation({
+      mutationFn: (params: {
+        questionId: number;
+        sessionId: string;
+        token: string;
+      }) =>
+        deleteQuestion(params.questionId, {
+          sessionId: params.sessionId,
+          token: params.token,
+        }),
+      onSuccess: () => {
+        addToast({
+          type: 'SUCCESS',
+          message: '질문을 삭제했습니다.',
+          duration: 3000,
+        });
+        removeQuestion(question.questionId);
+      },
+    });
 
-    deleteQuestion(question.questionId, {
+  const handleDelete = () => {
+    if (expired || !sessionToken || !sessionId || isDeleteInProgress) return;
+
+    deleteQuestionQuery({
+      questionId: question.questionId,
       sessionId,
       token: sessionToken,
-    }).then(() => {
-      addToast({
-        type: 'SUCCESS',
-        message: '질문을 삭제했습니다.',
-        duration: 3000,
-      });
-      removeQuestion(question.questionId);
     });
   };
 

--- a/apps/client/src/components/qna/ReplyItem.tsx
+++ b/apps/client/src/components/qna/ReplyItem.tsx
@@ -1,4 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
+import { throttle } from 'es-toolkit';
+import { useCallback } from 'react';
 import { FiEdit2 } from 'react-icons/fi';
 import { GrClose, GrLike, GrLikeFill, GrValidate } from 'react-icons/gr';
 import Markdown from 'react-markdown';
@@ -55,22 +57,29 @@ function ReplyItem({ question, reply }: ReplyItemProps) {
       },
     });
 
-  const handleToggleLike = () => {
-    if (
-      expired ||
-      !sessionId ||
-      !sessionToken ||
-      isLikeInProgress ||
-      reply.deleted
-    )
-      return;
+  const handleLike = useCallback(
+    throttle(
+      () => {
+        if (
+          expired ||
+          !sessionId ||
+          !sessionToken ||
+          isLikeInProgress ||
+          reply.deleted
+        )
+          return;
 
-    postReplyLikeQuery({
-      replyId: reply.replyId,
-      sessionId,
-      token: sessionToken,
-    });
-  };
+        postReplyLikeQuery({
+          replyId: reply.replyId,
+          sessionId,
+          token: sessionToken,
+        });
+      },
+      1000,
+      { edges: ['leading'] },
+    ),
+    [],
+  );
 
   const { mutate: deleteReplyQuery, isPending: isDeleteInProgress } =
     useMutation({
@@ -124,7 +133,7 @@ function ReplyItem({ question, reply }: ReplyItemProps) {
           <div className='inline-flex w-full items-center justify-between'>
             <Button
               className='hover:bg-gray-200/50 hover:transition-all'
-              onClick={handleToggleLike}
+              onClick={handleLike}
             >
               <div className='flex flex-row items-center gap-2 text-sm font-medium text-gray-500'>
                 {reply.liked ? (

--- a/apps/client/src/features/auth/auth.hook.ts
+++ b/apps/client/src/features/auth/auth.hook.ts
@@ -1,9 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
 import { useRouterState } from '@tanstack/react-router';
 import { isAxiosError } from 'axios';
 import { useState } from 'react';
 
 import { login } from '@/features/auth/auth.api';
 import { useAuthStore } from '@/features/auth/auth.store';
+import { useToastStore } from '@/features/toast';
 
 import { ValidationStatusWithMessage } from '@/shared';
 
@@ -12,39 +14,51 @@ export function useSignInForm() {
 
   const { setAccessToken } = useAuthStore();
 
+  const { addToast } = useToastStore();
+
   const [email, setEmail] = useState('');
 
   const [password, setPassword] = useState('');
-
-  const isLoginEnabled = email.length > 0 && password.length > 7;
 
   const [loginFailed, setLoginFailed] = useState<ValidationStatusWithMessage>({
     status: 'INITIAL',
   });
 
-  const handleLogin = async () => {
-    try {
-      const response = await login({ email, password });
+  const { mutate, isPending } = useMutation({
+    mutationFn: (credentials: { email: string; password: string }) =>
+      login(credentials),
+    onSuccess: (response) => {
+      addToast({
+        type: 'SUCCESS',
+        message: '로그인 되었습니다.',
+        duration: 3000,
+      });
       setAccessToken(response.accessToken);
-      if (router.location.pathname.includes('session'))
+      if (router.location.pathname.includes('session')) {
         window.location.reload();
-    } catch (e) {
-      if (isAxiosError(e) && e.response) {
-        if (e.response.status === 400) {
+      }
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response) {
+        if (error.response.status === 400) {
           setLoginFailed({
             status: 'INVALID',
-            message: e.response.data.messages.shift(),
+            message: error.response.data.messages.shift(),
           });
-        } else if (e.response.status === 401) {
+        } else if (error.response.status === 401) {
           setLoginFailed({
             status: 'INVALID',
-            message: e.response.data.message,
+            message: error.response.data.message,
           });
         }
       }
-      throw e;
-    }
-  };
+    },
+  });
+
+  const isLoginEnabled = email.length > 0 && password.length > 7 && !isPending;
+
+  const handleLogin = (callback: () => void) =>
+    mutate({ email, password }, { onSettled: callback });
 
   return {
     email,

--- a/apps/client/src/features/auth/auth.hook.ts
+++ b/apps/client/src/features/auth/auth.hook.ts
@@ -24,7 +24,7 @@ export function useSignInForm() {
     status: 'INITIAL',
   });
 
-  const { mutate, isPending } = useMutation({
+  const { mutate: loginQuery, isPending } = useMutation({
     mutationFn: (credentials: { email: string; password: string }) =>
       login(credentials),
     onSuccess: (response) => {
@@ -58,7 +58,7 @@ export function useSignInForm() {
   const isLoginEnabled = email.length > 0 && password.length > 7 && !isPending;
 
   const handleLogin = (callback: () => void) =>
-    mutate({ email, password }, { onSettled: callback });
+    loginQuery({ email, password }, { onSettled: callback });
 
   return {
     email,


### PR DESCRIPTION
## 개요

- 중복된 요청을 금지합니다.
  - 서버로부터 응답을 받기 전 클라이언트가 재요청할 수 없도록 수정했습니다.
- 좋아요 기능의 경우에는 1초에 1번만 요청할 수 있게 수정했습니다.

## 이슈

- close #164
- close #167
