### PR TITLE
feat(fe): implement multi-host ui

### DIFF
--- a/apps/client/src/components/index.ts
+++ b/apps/client/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as QuestionDetail } from './qna/QuestionDetail';
 export { default as ChattingList } from './qna/ChattingList';
 export { default as CreateQuestionModal } from './modal/CreateQuestionModal';
 export { default as CreateReplyModal } from './modal/CreateReplyModal';
+export { default as SessionParticipantsModal } from './modal/SessionParticipantsModal';

--- a/apps/client/src/components/modal/Participant.tsx
+++ b/apps/client/src/components/modal/Participant.tsx
@@ -1,0 +1,26 @@
+import { GrValidate } from 'react-icons/gr';
+
+interface ParticipantProps {
+  name: string;
+  isHost: boolean;
+  onSelect: () => void;
+}
+
+function Participant({ name, isHost, onSelect }: ParticipantProps) {
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div
+      onClick={onSelect}
+      className='w-full cursor-pointer rounded hover:bg-gray-200'
+    >
+      <div className='flex w-full flex-row items-center gap-2 p-2'>
+        <GrValidate
+          className={`flex-shrink-0 ${isHost ? 'text-indigo-600' : 'text-black-200'}`}
+        />
+        <span className='font-medium'>{name}</span>
+      </div>
+    </div>
+  );
+}
+
+export default Participant;

--- a/apps/client/src/components/modal/SessionParticipantsModal.tsx
+++ b/apps/client/src/components/modal/SessionParticipantsModal.tsx
@@ -30,7 +30,11 @@ function SessionParticipantsModal() {
               <span>님을</span>
             </span>
             <br />
-            <span>호스트로 지정하겠습니까?</span>
+            <span>
+              {selectedUser.isHost
+                ? '호스트를 해제하겠습니까?'
+                : '호스트로 지정하겠습니까?'}
+            </span>
           </div>
           <div className='mx-auto mt-4 inline-flex min-w-[22.5dvw] items-start justify-center gap-2.5'>
             <Button

--- a/apps/client/src/components/modal/SessionParticipantsModal.tsx
+++ b/apps/client/src/components/modal/SessionParticipantsModal.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { IoClose } from 'react-icons/io5';
+
+import { useModalContext } from '@/features/modal';
+
+import { Button } from '@/components';
+import Participant from '@/components/modal/Participant';
+
+function SessionParticipantsModal() {
+  const { closeModal } = useModalContext();
+
+  const [selectedUserId, setSelectedUserId] = useState<number>();
+
+  const participantList = [
+    { id: 1, name: '최정민', isHost: false },
+    { id: 2, name: '이상현', isHost: true },
+    { id: 3, name: '유영재', isHost: false },
+    { id: 4, name: '이지호', isHost: true },
+  ];
+
+  const selectedUser = participantList.find(({ id }) => id === selectedUserId);
+
+  return (
+    <div className='inline-flex flex-col items-center justify-center gap-2.5 rounded-lg bg-gray-50 p-8 shadow'>
+      {selectedUser ? (
+        <div className='flex h-[15dvh] w-full min-w-[25dvw] flex-col justify-center gap-2'>
+          <div className='w-full text-center font-bold'>
+            <span>
+              <span className='text-indigo-600'>{selectedUser.name}</span>
+              <span>님을</span>
+            </span>
+            <br />
+            <span>호스트로 지정하겠습니까?</span>
+          </div>
+          <div className='mx-auto mt-4 inline-flex min-w-[22.5dvw] items-start justify-center gap-2.5'>
+            <Button
+              className='w-full bg-gray-500'
+              onClick={() => setSelectedUserId(undefined)}
+            >
+              <div className='flex-grow text-sm font-medium text-white'>
+                취소하기
+              </div>
+            </Button>
+            <Button
+              className='w-full bg-indigo-600 transition-colors duration-200'
+              onClick={() => {
+                // TODO: 호스트 지정 API 호출
+              }}
+            >
+              <div className='flex-grow text-sm font-medium text-white'>
+                지정하기
+              </div>
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className='flex h-[25dvh] w-full min-w-[25dvw] flex-col gap-2'>
+          <div className='flex flex-row items-center justify-between border-b border-gray-200 pb-2'>
+            <span className='text-lg font-bold'>세션 참여자 정보</span>
+            <IoClose
+              size={24}
+              className='cursor-pointer text-rose-600 transition-transform duration-100 hover:scale-110'
+              onClick={closeModal}
+            />
+          </div>
+          <ol className='flex w-full flex-col gap-2 overflow-y-auto overflow-x-hidden'>
+            {participantList.map(({ id, name, isHost }) => (
+              <Participant
+                name={name}
+                isHost={isHost}
+                onSelect={() => setSelectedUserId(id)}
+              />
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SessionParticipantsModal;

--- a/apps/client/src/components/qna/ChattingList.tsx
+++ b/apps/client/src/components/qna/ChattingList.tsx
@@ -1,12 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useModal } from '@/features/modal';
 import { useSessionStore } from '@/features/session';
 import { useSocket } from '@/features/socket';
 
+import { SessionParticipantsModal } from '@/components';
+import Button from '@/components/Button';
 import ChattingMessage from '@/components/qna/ChattingMessage';
 
 function ChattingList() {
   const { chatting } = useSessionStore();
+
+  const { Modal, openModal } = useModal(<SessionParticipantsModal />);
 
   const [message, setMessage] = useState('');
   const [isBottom, setIsBottom] = useState(true);
@@ -61,68 +66,75 @@ function ChattingList() {
   }, [chatting, isBottom]);
 
   return (
-    <div className='inline-flex h-full w-1/5 min-w-[240px] flex-col items-center justify-start rounded-lg bg-white shadow'>
-      <div className='inline-flex h-[54px] w-full items-center justify-between border-b border-gray-200 px-4 py-3'>
-        <div className='shrink grow basis-0 text-lg font-medium text-black'>
-          실시간 채팅
-        </div>
-        {/* TODO: 백엔드 추가 되면 진행 */}
-        {/* <div className='flex items-center justify-center gap-2.5 rounded bg-green-100 px-2 py-1'>
-          <p className='text-[10px] font-medium text-green-800'>123명 참여중</p>
-        </div> */}
-      </div>
-
-      <div
-        className='inline-flex h-full w-full flex-col items-start justify-start overflow-y-auto break-words p-2.5 scrollbar-hide'
-        ref={messagesEndRef}
-      >
-        {chatting.map((chat) => (
-          <ChattingMessage key={chat.chattingId} chat={chat} />
-        ))}
-      </div>
-
-      <div className='relative inline-flex h-[75px] w-full items-center justify-center gap-2.5 border-t border-gray-200 bg-gray-50 p-4'>
-        {!isBottom && userScrolling.current && (
-          <button
-            type='button'
-            onClick={scrollToBottom}
-            className='absolute bottom-[110%] rounded-full bg-indigo-500 p-2 text-white shadow-lg transition-all hover:bg-indigo-600'
-            aria-label='맨 아래로 스크롤'
+    <>
+      <div className='inline-flex h-full w-1/5 min-w-[240px] flex-col items-center justify-start rounded-lg bg-white shadow'>
+        <div className='inline-flex h-[54px] w-full items-center justify-between border-b border-gray-200 px-4 py-3'>
+          <div className='shrink grow basis-0 text-lg font-medium text-black'>
+            실시간 채팅
+          </div>
+          <Button
+            className='max-w-[100px] overflow-x-auto whitespace-nowrap bg-green-100 px-2 py-1 transition-colors duration-150 scrollbar-hide hover:bg-green-200'
+            onClick={openModal}
           >
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              className='h-5 w-5'
-              viewBox='0 0 20 20'
-              fill='currentColor'
+            <p className='text-[10px] font-medium text-green-800'>
+              123123123명 참여중
+            </p>
+          </Button>
+        </div>
+
+        <div
+          className='inline-flex h-full w-full flex-col items-start justify-start overflow-y-auto break-words p-2.5 scrollbar-hide'
+          ref={messagesEndRef}
+        >
+          {chatting.map((chat) => (
+            <ChattingMessage key={chat.chattingId} chat={chat} />
+          ))}
+        </div>
+
+        <div className='relative inline-flex h-[75px] w-full items-center justify-center gap-2.5 border-t border-gray-200 bg-gray-50 p-4'>
+          {!isBottom && userScrolling.current && (
+            <button
+              type='button'
+              onClick={scrollToBottom}
+              className='absolute bottom-[110%] rounded-full bg-indigo-500 p-2 text-white shadow-lg transition-all hover:bg-indigo-600'
+              aria-label='맨 아래로 스크롤'
             >
-              <path
-                fillRule='evenodd'
-                d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z'
-                clipRule='evenodd'
-              />
-            </svg>
-          </button>
-        )}
-        <div className='flex w-full items-center justify-center self-stretch rounded-md border border-gray-200 bg-white p-3'>
-          <input
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={(e) => {
-              if (
-                e.key === 'Enter' &&
-                !e.nativeEvent.isComposing &&
-                message.trim().length
-              ) {
-                socket?.sendChatMessage(message);
-                setMessage('');
-              }
-            }}
-            className='w-full text-sm font-medium text-gray-500 focus:outline-none'
-            placeholder='채팅 메시지를 입력해주세요'
-          />
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                className='h-5 w-5'
+                viewBox='0 0 20 20'
+                fill='currentColor'
+              >
+                <path
+                  fillRule='evenodd'
+                  d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z'
+                  clipRule='evenodd'
+                />
+              </svg>
+            </button>
+          )}
+          <div className='flex w-full items-center justify-center self-stretch rounded-md border border-gray-200 bg-white p-3'>
+            <input
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={(e) => {
+                if (
+                  e.key === 'Enter' &&
+                  !e.nativeEvent.isComposing &&
+                  message.trim().length
+                ) {
+                  socket?.sendChatMessage(message);
+                  setMessage('');
+                }
+              }}
+              className='w-full text-sm font-medium text-gray-500 focus:outline-none'
+              placeholder='채팅 메시지를 입력해주세요'
+            />
+          </div>
         </div>
       </div>
-    </div>
+      {Modal}
+    </>
   );
 }
 

--- a/apps/client/src/features/toast/ToastContainer.tsx
+++ b/apps/client/src/features/toast/ToastContainer.tsx
@@ -1,15 +1,18 @@
+import { createPortal } from 'react-dom';
+
 import { useToastStore } from '@/features/toast/toast.store';
 import ToastMessage from '@/features/toast/ToastMessage';
 
 function ToastContainer() {
   const toasts = useToastStore((state) => state.toasts);
 
-  return (
-    <div className='fixed bottom-4 left-4 flex h-fit w-fit min-w-[200px] max-w-[300px] flex-col gap-4'>
+  return createPortal(
+    <div className='fixed bottom-4 left-4 z-20 flex h-fit w-fit min-w-[200px] max-w-[300px] flex-col gap-4'>
       {toasts.map((toast) => (
         <ToastMessage key={toast.id} toast={toast} />
       ))}
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/apps/client/src/features/toast/ToastMessage.tsx
+++ b/apps/client/src/features/toast/ToastMessage.tsx
@@ -72,7 +72,7 @@ function ToastMessage({ toast }: { toast: Toast }) {
 
   return (
     <div
-      className={`w-fit min-w-[200px] max-w-[300px] overflow-hidden p-4 font-medium shadow ${toast.isActive ? 'animate-fadeIn' : 'animate-fadeOut'} ${getToastClass(toast.type)}`}
+      className={`w-fit min-w-[200px] max-w-[300px] overflow-hidden rounded p-4 font-medium shadow ${toast.isActive ? 'animate-fadeIn' : 'animate-fadeOut'} ${getToastClass(toast.type)}`}
     >
       {toast.message}
       <div className='relative mt-2 h-1 rounded-full bg-gray-200'>


### PR DESCRIPTION
## 개요

- 멀티 호스트를 위한 UI를 구현했습니다.
  - 현재 더미 데이터를 이용하여 구현되어있습니다.
- 토스트 메시지가 모달이 보여질 때 가려지는 현상을 수정했습니다.

<div align='center'>

<img width="30%" alt="스크린샷 2024-11-26 18 35 12" src="https://github.com/user-attachments/assets/258bcdec-a379-4441-9056-7ce5376deb31">

<img width="30%" alt="스크린샷 2024-11-26 18 35 19" src="https://github.com/user-attachments/assets/564de10a-9c05-4755-9e75-e68d06d8c4d7">

<img width="30%" alt="image" src="https://github.com/user-attachments/assets/299c3c9c-0ee0-4513-ac4f-221e1c1fb51b">

</div>


## 이슈

- close #186 
