### PR TITLE
feat(fe): custom scroll bar

### DIFF
--- a/apps/client/src/components/qna/ChattingList.tsx
+++ b/apps/client/src/components/qna/ChattingList.tsx
@@ -83,7 +83,7 @@ function ChattingList() {
         </div>
 
         <div
-          className='inline-flex h-full w-full flex-col items-start justify-start overflow-y-auto break-words p-2.5 scrollbar-hide'
+          className='inline-flex h-full w-full flex-col items-start justify-start overflow-y-auto overflow-x-hidden break-words p-2.5'
           ref={messagesEndRef}
         >
           {chatting.map((chat) => (

--- a/apps/client/src/components/qna/QuestionDetail.tsx
+++ b/apps/client/src/components/qna/QuestionDetail.tsx
@@ -48,7 +48,7 @@ function QuestionDetail() {
           )}
         </div>
 
-        <div className='inline-flex h-full w-full flex-col items-start justify-start gap-4 overflow-y-auto pb-4 scrollbar-hide'>
+        <div className='inline-flex h-full w-full flex-col items-start justify-start gap-4 overflow-y-auto pb-4'>
           <div className='flex h-fit flex-col items-start justify-center gap-2.5 self-stretch border-b border-gray-200/50 px-12 py-4'>
             <Markdown className='prose prose-stone flex w-full flex-col gap-3 self-stretch text-base font-medium leading-normal text-black prose-img:rounded-md'>
               {question.body}

--- a/apps/client/src/components/qna/QuestionList.tsx
+++ b/apps/client/src/components/qna/QuestionList.tsx
@@ -51,7 +51,7 @@ function QuestionList() {
             </Button>
           )}
         </div>
-        <motion.div className='inline-flex h-full w-full flex-col items-start justify-start gap-4 overflow-y-auto px-8 py-4 scrollbar-hide'>
+        <motion.div className='inline-flex h-full w-full flex-col items-start justify-start gap-4 overflow-y-auto px-8 py-4'>
           {sections.map((section) => (
             <QuestionSection
               key={section.title}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -11,3 +11,21 @@
 * {
   user-select: none;
 }
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #e5e7eb;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #a5b4fc;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #6366f1;
+}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -8,10 +8,6 @@
   margin: 0;
 }
 
-* {
-  user-select: none;
-}
-
 ::-webkit-scrollbar {
   width: 8px;
 }

--- a/apps/client/src/pages/MyPage.tsx
+++ b/apps/client/src/pages/MyPage.tsx
@@ -11,7 +11,7 @@ function MyPage() {
 
   return (
     <div className='inline-flex h-full w-full items-center justify-center gap-4 overflow-hidden px-4 py-4 md:max-w-[1194px]'>
-      <div className='inline-flex shrink grow basis-0 flex-col items-center justify-start gap-4 self-stretch rounded-lg bg-white shadow'>
+      <div className='inline-flex shrink grow basis-0 flex-col items-center justify-start self-stretch rounded-lg bg-white shadow'>
         <div className='inline-flex h-[54px] items-center justify-between self-stretch border-b border-gray-200 px-8 py-2'>
           <div className='text-lg font-medium text-black'>참여한 세션 기록</div>
           <div className='rounded-md px-3 py-2' />


### PR DESCRIPTION
## 개요

- 운영체제별 일관되지 않은 스크롤바를 이유로 제거했던 스크롤바를 커스텀하여 추가했습니다.
  - 세션 기록, 질문 목록, 상세 질문, 채팅창에 새롭게 적용되었습니다.
  - 기본 스크롤이 더 낫다고 판단되면 제거할 예정입니다.
- 사용자 경험을 위해 드래그 금지를 해제했습니다.
- 윈도우즈의 경우, 채팅창에서 가로 스크롤이 확인되었던 것이 현재 개발 환경에서 확인이 불가하여, 추후에 확인 바랍니다.

<div align='center'>
<img width="75%" alt="image" src="https://github.com/user-attachments/assets/b131443a-26d3-49c5-9f26-1c9b336ca03f">
</div>

## 이슈

- close #190 
