### PR TITLE
refactor(be): remove unnecessary refresh token check in jwt auth guard

### DIFF
--- a/apps/server/src/auth/auth.service.ts
+++ b/apps/server/src/auth/auth.service.ts
@@ -93,12 +93,6 @@ export class AuthService implements OnModuleInit {
     }
   }
 
-  hasValidRefreshToken(userId: number, nickname: string) {
-    return Object.values(this.refreshTokens).some(
-      (data) => data.userId === userId && data.nickname === nickname && data.expiredAt > new Date(),
-    );
-  }
-
   removeRefreshToken(refreshToken: string) {
     delete this.refreshTokens[refreshToken];
   }

--- a/apps/server/src/auth/jwt-auth.guard.ts
+++ b/apps/server/src/auth/jwt-auth.guard.ts
@@ -2,15 +2,12 @@ import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 
-import { AuthService } from './auth.service';
 import { JwtAuthException } from './exceptions/auth.exception';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
-  constructor(
-    private readonly jwtService: JwtService,
-    private readonly authService: AuthService,
-  ) {}
+  constructor(private readonly jwtService: JwtService) {}
+
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest<Request>();
     const token = this.extractToken(request);
@@ -18,9 +15,6 @@ export class JwtAuthGuard implements CanActivate {
 
     try {
       const payload = await this.jwtService.verifyAsync(token, { secret: process.env.JWT_ACCESS_SECRET });
-
-      const validation = this.authService.hasValidRefreshToken(payload.userId, payload.nickname);
-      if (!validation) throw JwtAuthException.invalidAccessToken();
 
       request['user'] = payload;
       return true;


### PR DESCRIPTION
## 개요

- JWT를 검증하는 Guard에서 불필요하게 세션 저장소를 확인하는 로직이 있음을 발견하고 제거하였습니다.
- JWT 검증에서 세션 저장소를 확인하면 JWT를 사용한 의미가 없는건데, 이런 로직을 짜놨더라구요. Wiki 쓰다가 발견하여 PR올립니다.

## 없슈