### PR TITLE
refactor(be): refactoring exception handling logic

### DIFF
--- a/apps/server/src/chats/chats.repository.ts
+++ b/apps/server/src/chats/chats.repository.ts
@@ -2,49 +2,40 @@ import { Injectable } from '@nestjs/common';
 
 import { ChatSaveDto } from './chats.service';
 
-import { DatabaseException } from '@common/exceptions/resource.exception';
 import { PrismaService } from '@prisma-alias/prisma.service';
 
 @Injectable()
 export class ChatsRepository {
   constructor(private readonly prisma: PrismaService) {}
   async save({ sessionId, token, body }: ChatSaveDto) {
-    try {
-      return await this.prisma.chatting.create({
-        data: { sessionId, createUserToken: token, body },
-        include: {
-          createUserTokenEntity: {
-            select: {
-              user: true,
-            },
+    return await this.prisma.chatting.create({
+      data: { sessionId, createUserToken: token, body },
+      include: {
+        createUserTokenEntity: {
+          select: {
+            user: true,
           },
         },
-      });
-    } catch (error) {
-      throw DatabaseException.create('chat');
-    }
+      },
+    });
   }
   async getChatsForInfiniteScroll(sessionId: string, count: number, chatId?: number) {
-    try {
-      return await this.prisma.chatting.findMany({
-        where: {
-          sessionId,
-          ...(chatId && { chattingId: { lt: chatId } }),
-        },
-        include: {
-          createUserTokenEntity: {
-            include: {
-              user: true,
-            },
+    return await this.prisma.chatting.findMany({
+      where: {
+        sessionId,
+        ...(chatId && { chattingId: { lt: chatId } }),
+      },
+      include: {
+        createUserTokenEntity: {
+          include: {
+            user: true,
           },
         },
-        orderBy: {
-          chattingId: 'desc',
-        },
-        take: count,
-      });
-    } catch (error) {
-      throw new Error('Error retrieving chats from database');
-    }
+      },
+      orderBy: {
+        chattingId: 'desc',
+      },
+      take: count,
+    });
   }
 }

--- a/apps/server/src/common/exceptions/resource.exception.ts
+++ b/apps/server/src/common/exceptions/resource.exception.ts
@@ -1,35 +1,7 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 
-export class ResourceNotFoundException extends HttpException {
-  constructor(resource: string) {
-    super(`${resource}를 찾을 수 없습니다.`, HttpStatus.NOT_FOUND);
-  }
-}
-
 export class ResourceConflictException extends HttpException {
   constructor(message: string) {
     super(message, HttpStatus.CONFLICT);
-  }
-}
-
-export class DatabaseException extends HttpException {
-  constructor(operation: string) {
-    super(`데이터베이스 ${operation} 중 오류가 발생했습니다`, HttpStatus.INTERNAL_SERVER_ERROR);
-  }
-
-  static create(entity: string) {
-    return new DatabaseException(`${entity} 생성`);
-  }
-
-  static read(entity: string) {
-    return new DatabaseException(`${entity} 조회`);
-  }
-
-  static update(entity: string) {
-    return new DatabaseException(`${entity} 수정`);
-  }
-
-  static delete(entity: string) {
-    return new DatabaseException(`${entity} 삭제`);
   }
 }

--- a/apps/server/src/common/guards/session-token-validation.guard.ts
+++ b/apps/server/src/common/guards/session-token-validation.guard.ts
@@ -10,11 +10,7 @@ export class SessionTokenValidationGuard implements CanActivate {
     private readonly sessionsAuthRepository: SessionsAuthRepository,
   ) {}
 
-  async canActivate(context: ExecutionContext) {
-    const request = context.switchToHttp().getRequest();
-    const sessionId = request.body?.sessionId || request.query?.sessionId || request.params?.sessionId;
-    const token = request.body?.token || request.query?.token;
-
+  async validateSessionToken(sessionId: string, token: string) {
     if (!sessionId || !token) {
       throw new ForbiddenException('세션 ID와 사용자 토큰이 필요합니다.');
     }
@@ -33,7 +29,14 @@ export class SessionTokenValidationGuard implements CanActivate {
     if (!userSessionToken || userSessionToken.sessionId !== sessionId) {
       throw new ForbiddenException('해당 세션에 접근할 권한이 없습니다.');
     }
+  }
 
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const sessionId = request.body?.sessionId || request.query?.sessionId || request.params?.sessionId;
+    const token = request.body?.token || request.query?.token;
+
+    await this.validateSessionToken(sessionId, token);
     return true;
   }
 }

--- a/apps/server/src/questions/questions.repository.ts
+++ b/apps/server/src/questions/questions.repository.ts
@@ -1,10 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 import { CreateQuestionDto } from './dto/create-question.dto';
 
-import { DatabaseException, ResourceNotFoundException } from '@common/exceptions/resource.exception';
-import { PRISMA_ERROR_CODE } from '@prisma-alias/prisma.error';
 import { PrismaService } from '@prisma-alias/prisma.service';
 
 @Injectable()
@@ -12,26 +9,18 @@ export class QuestionsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findById(questionId: number) {
-    try {
-      return await this.prisma.question.findUnique({
-        where: { questionId },
-      });
-    } catch (error) {
-      throw DatabaseException.read('question');
-    }
+    return await this.prisma.question.findUnique({
+      where: { questionId },
+    });
   }
 
   async findByIdAndSession(questionId: number, sessionId: string) {
-    try {
-      return await this.prisma.question.findUnique({
-        where: {
-          questionId,
-          sessionId,
-        },
-      });
-    } catch (error) {
-      throw DatabaseException.read('question');
-    }
+    return await this.prisma.question.findUnique({
+      where: {
+        questionId,
+        sessionId,
+      },
+    });
   }
 
   async create({ sessionId, token: createUserToken, body }: CreateQuestionDto) {
@@ -42,155 +31,108 @@ export class QuestionsRepository {
       pinned: false,
       closed: false,
     };
-    try {
-      return await this.prisma.question.create({
-        data: questionData,
-        include: {
-          createUserTokenEntity: {
-            select: {
-              user: {
-                select: { nickname: true },
-              },
+    return await this.prisma.question.create({
+      data: questionData,
+      include: {
+        createUserTokenEntity: {
+          select: {
+            user: {
+              select: { nickname: true },
             },
           },
         },
-      });
-    } catch (error) {
-      throw DatabaseException.create('question');
-    }
+      },
+    });
   }
 
   async findQuestionsWithDetails(sessionId: string) {
-    try {
-      return await this.prisma.question.findMany({
-        where: { sessionId },
-        orderBy: { questionId: 'asc' },
-        include: {
-          questionLikes: {
-            select: {
-              createUserToken: true,
-            },
+    return await this.prisma.question.findMany({
+      where: { sessionId },
+      orderBy: { questionId: 'asc' },
+      include: {
+        questionLikes: {
+          select: {
+            createUserToken: true,
           },
-          createUserTokenEntity: {
-            select: {
-              user: true,
-            },
+        },
+        createUserTokenEntity: {
+          select: {
+            user: true,
           },
-          replies: {
-            orderBy: { replyId: 'asc' },
-            include: {
-              createUserTokenEntity: {
-                select: {
-                  user: true,
-                },
+        },
+        replies: {
+          orderBy: { replyId: 'asc' },
+          include: {
+            createUserTokenEntity: {
+              select: {
+                user: true,
               },
-              replyLikes: {
-                select: {
-                  createUserToken: true,
-                },
+            },
+            replyLikes: {
+              select: {
+                createUserToken: true,
               },
             },
           },
         },
-      });
-    } catch (error) {
-      throw DatabaseException.read('question');
-    }
+      },
+    });
   }
 
   async updateBody(questionId: number, body: string) {
-    try {
-      return await this.prisma.question.update({
-        where: { questionId },
-        data: { body },
-      });
-    } catch (error) {
-      throw DatabaseException.update('question');
-    }
+    return await this.prisma.question.update({
+      where: { questionId },
+      data: { body },
+    });
   }
 
   async deleteQuestion(questionId: number) {
-    try {
-      return await this.prisma.question.delete({
-        where: { questionId },
-      });
-    } catch (error) {
-      throw DatabaseException.delete('question');
-    }
+    return await this.prisma.question.delete({
+      where: { questionId },
+    });
   }
 
   async updatePinned(questionId: number, pinned: boolean) {
-    try {
-      return await this.prisma.question.update({
-        where: { questionId },
-        data: { pinned },
-      });
-    } catch (error) {
-      throw DatabaseException.update('question');
-    }
+    return await this.prisma.question.update({
+      where: { questionId },
+      data: { pinned },
+    });
   }
 
   async updateClosed(questionId: number, closed: boolean) {
-    try {
-      return await this.prisma.question.update({
-        where: { questionId },
-        data: { closed },
-      });
-    } catch (error) {
-      throw DatabaseException.update('question');
-    }
+    return await this.prisma.question.update({
+      where: { questionId },
+      data: { closed },
+    });
   }
 
   async findLike(questionId: number, createUserToken: string) {
-    try {
-      return await this.prisma.questionLike.findFirst({
-        where: {
-          questionId,
-          createUserToken,
-        },
-      });
-    } catch (error) {
-      throw DatabaseException.read('questionLike');
-    }
+    return await this.prisma.questionLike.findFirst({
+      where: {
+        questionId,
+        createUserToken,
+      },
+    });
   }
 
   async createLike(questionId: number, createUserToken: string) {
-    try {
-      await this.prisma.questionLike.create({
-        data: {
-          questionId,
-          createUserToken,
-        },
-      });
-    } catch (error) {
-      if (
-        error instanceof PrismaClientKnownRequestError &&
-        error.code === PRISMA_ERROR_CODE.FOREIGN_KEY_CONSTRAINT_VIOLATION
-      ) {
-        if (error.message.includes('questionId')) throw new ResourceNotFoundException('questionId');
-        if (error.message.includes('createUserToken')) throw new ResourceNotFoundException('createUserToken');
-      }
-      throw DatabaseException.create('questionLike');
-    }
+    await this.prisma.questionLike.create({
+      data: {
+        questionId,
+        createUserToken,
+      },
+    });
   }
 
   async deleteLike(questionLikeId: number) {
-    try {
-      await this.prisma.questionLike.delete({
-        where: { questionLikeId },
-      });
-    } catch (error) {
-      throw DatabaseException.delete('questionLike');
-    }
+    await this.prisma.questionLike.delete({
+      where: { questionLikeId },
+    });
   }
 
   async getLikesCount(questionId: number) {
-    try {
-      return await this.prisma.questionLike.count({
-        where: { questionId },
-      });
-    } catch (error) {
-      throw DatabaseException.read('questionLike');
-    }
+    return await this.prisma.questionLike.count({
+      where: { questionId },
+    });
   }
 }

--- a/apps/server/src/questions/questions.service.ts
+++ b/apps/server/src/questions/questions.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { Question } from '@prisma/client';
 
 import { CreateQuestionDto } from './dto/create-question.dto';
@@ -46,6 +46,9 @@ export class QuestionsService {
       this.sessionAuthRepository.findHostTokensInSession(sessionId),
     ]);
 
+    if (!session) {
+      throw new NotFoundException('존재하지않는 세션입니다.');
+    }
     const expired = session.expiredAt < new Date();
     const isHost = sessionHostTokens.some(({ token: hostToken }) => hostToken === token);
     const mapLikesAndOwnership = <

--- a/apps/server/src/replies/replies.repository.ts
+++ b/apps/server/src/replies/replies.repository.ts
@@ -1,10 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 import { CreateReplyDto } from './dto/create-reply.dto';
 
-import { DatabaseException, ResourceNotFoundException } from '@common/exceptions/resource.exception';
-import { PRISMA_ERROR_CODE } from '@prisma-alias/prisma.error';
 import { PrismaService } from '@prisma-alias/prisma.service';
 
 @Injectable()
@@ -18,42 +15,30 @@ export class RepliesRepository {
       sessionId,
       body,
     };
-    try {
-      return await this.prisma.reply.create({
-        data: replyData,
-        include: {
-          createUserTokenEntity: {
-            select: {
-              user: true,
-            },
+    return await this.prisma.reply.create({
+      data: replyData,
+      include: {
+        createUserTokenEntity: {
+          select: {
+            user: true,
           },
         },
-      });
-    } catch (error) {
-      throw DatabaseException.create('Reply');
-    }
+      },
+    });
   }
 
   async updateBody(replyId: number, body: string) {
-    try {
-      return await this.prisma.reply.update({
-        where: { replyId },
-        data: { body },
-      });
-    } catch (error) {
-      throw DatabaseException.update('reply');
-    }
+    return await this.prisma.reply.update({
+      where: { replyId },
+      data: { body },
+    });
   }
 
   async deleteReply(replyId: number) {
-    try {
-      return await this.prisma.reply.update({
-        where: { replyId },
-        data: { deleted: true },
-      });
-    } catch (error) {
-      throw DatabaseException.delete('reply');
-    }
+    return await this.prisma.reply.update({
+      where: { replyId },
+      data: { deleted: true },
+    });
   }
 
   async findReplyByQuestionId(questionId: number) {
@@ -64,71 +49,44 @@ export class RepliesRepository {
   }
 
   async findReplyByIdAndSessionId(replyId: number, sessionId: string) {
-    try {
-      return await this.prisma.reply.findFirst({
-        where: { replyId, sessionId, deleted: false },
-      });
-    } catch (error) {
-      throw DatabaseException.read('reply');
-    }
+    return await this.prisma.reply.findFirst({
+      where: { replyId, sessionId, deleted: false },
+    });
   }
 
   async findLike(replyId: number, createUserToken: string) {
-    try {
-      return await this.prisma.replyLike.findFirst({
-        where: {
-          replyId,
-          createUserToken,
-        },
-      });
-    } catch (error) {
-      throw DatabaseException.read('replyLike');
-    }
+    return await this.prisma.replyLike.findFirst({
+      where: {
+        replyId,
+        createUserToken,
+      },
+    });
   }
 
   async createLike(replyId: number, createUserToken: string) {
-    try {
-      return await this.prisma.replyLike.create({
-        data: {
-          replyId,
-          createUserToken,
-        },
-        include: {
-          reply: true,
-        },
-      });
-    } catch (error) {
-      if (
-        error instanceof PrismaClientKnownRequestError &&
-        error.code === PRISMA_ERROR_CODE.FOREIGN_KEY_CONSTRAINT_VIOLATION
-      ) {
-        if (error.message.includes('replyId')) throw new ResourceNotFoundException('replyId');
-        if (error.message.includes('createUserToken')) throw new ResourceNotFoundException('createUserToken');
-      }
-      throw DatabaseException.create('replyLike');
-    }
+    return await this.prisma.replyLike.create({
+      data: {
+        replyId,
+        createUserToken,
+      },
+      include: {
+        reply: true,
+      },
+    });
   }
 
   async deleteLike(replyLikeId: number) {
-    try {
-      return await this.prisma.replyLike.delete({
-        where: { replyLikeId },
-        include: {
-          reply: true,
-        },
-      });
-    } catch (error) {
-      throw DatabaseException.delete('replyLike');
-    }
+    return await this.prisma.replyLike.delete({
+      where: { replyLikeId },
+      include: {
+        reply: true,
+      },
+    });
   }
 
   async getLikesCount(replyId: number) {
-    try {
-      return await this.prisma.replyLike.count({
-        where: { replyId },
-      });
-    } catch (error) {
-      throw DatabaseException.read('replyLike');
-    }
+    return await this.prisma.replyLike.count({
+      where: { replyId },
+    });
   }
 }

--- a/apps/server/src/sessions-auth/sessions-auth.repository.ts
+++ b/apps/server/src/sessions-auth/sessions-auth.repository.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { v4 as uuid4 } from 'uuid';
 
-import { DatabaseException } from '@common/exceptions/resource.exception';
 import { PrismaService } from '@prisma-alias/prisma.service';
 
 @Injectable()
@@ -34,11 +33,7 @@ export class SessionsAuthRepository {
   }
 
   async findHostTokensInSession(sessionId: string) {
-    try {
-      return await this.prisma.userSessionToken.findMany({ where: { sessionId, isHost: true } });
-    } catch (error) {
-      throw DatabaseException.read('UserSessionToken');
-    }
+    return await this.prisma.userSessionToken.findMany({ where: { sessionId, isHost: true } });
   }
 
   async findTokenByToken(sessionId: string, token: string) {
@@ -56,15 +51,11 @@ export class SessionsAuthRepository {
   }
 
   async findByToken(token: string) {
-    try {
-      return await this.prisma.userSessionToken.findFirst({
-        where: {
-          token,
-        },
-      });
-    } catch (error) {
-      throw DatabaseException.read('UserSessionToken');
-    }
+    return await this.prisma.userSessionToken.findFirst({
+      where: {
+        token,
+      },
+    });
   }
 
   async findTokenByUserIdAndToken(userId: number, sessionId: string, token: string) {
@@ -83,49 +74,37 @@ export class SessionsAuthRepository {
   }
 
   async findByIdAndSession(replyId: number, sessionId: string) {
-    try {
-      return await this.prisma.reply.findUnique({
-        where: { replyId, sessionId },
-      });
-    } catch (error) {
-      throw DatabaseException.read('reply');
-    }
+    return await this.prisma.reply.findUnique({
+      where: { replyId, sessionId },
+    });
   }
 
   async findUsersBySessionId(sessionId: string) {
-    try {
-      return await this.prisma.userSessionToken.findMany({
-        where: {
-          sessionId,
-          userId: {
-            not: null,
+    return await this.prisma.userSessionToken.findMany({
+      where: {
+        sessionId,
+        userId: {
+          not: null,
+        },
+      },
+      include: {
+        user: {
+          select: {
+            userId: true,
+            nickname: true,
           },
         },
-        include: {
-          user: {
-            select: {
-              userId: true,
-              nickname: true,
-            },
-          },
-        },
-      });
-    } catch (error) {
-      throw DatabaseException.read('UserSessionToken');
-    }
+      },
+    });
   }
 
   async updateIsHost(token: string, isHost: boolean) {
-    try {
-      return await this.prisma.userSessionToken.update({
-        where: {
-          token,
-        },
-        data: { isHost },
-        select: { user: true, isHost: true },
-      });
-    } catch (error) {
-      throw DatabaseException.update('UserSessionToken');
-    }
+    return await this.prisma.userSessionToken.update({
+      where: {
+        token,
+      },
+      data: { isHost },
+      select: { user: true, isHost: true },
+    });
   }
 }

--- a/apps/server/src/sessions/sessions.repository.ts
+++ b/apps/server/src/sessions/sessions.repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 
 import { SessionCreateData } from './interface/session-create-data.interface';
 
-import { DatabaseException } from '@common/exceptions/resource.exception';
 import { PrismaService } from '@prisma-alias/prisma.service';
 
 @Injectable()
@@ -10,61 +9,43 @@ export class SessionsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(data: SessionCreateData) {
-    try {
-      return await this.prisma.session.create({ data });
-    } catch (error) {
-      throw DatabaseException.create('session');
-    }
+    return await this.prisma.session.create({ data });
   }
 
   async findById(sessionId: string) {
-    try {
-      return await this.prisma.session.findUnique({
-        where: { sessionId },
-      });
-    } catch (error) {
-      throw DatabaseException.read('session');
-    }
+    return await this.prisma.session.findUnique({
+      where: { sessionId },
+    });
   }
 
   async getSessionsById(userId: number) {
-    try {
-      const userSessions = await this.prisma.userSessionToken.findMany({
-        where: { userId },
-        select: {
-          sessionId: true,
-        },
-      });
-      const sessionIds = userSessions.map((session) => session.sessionId);
-
-      const sessions = await this.prisma.session.findMany({
-        where: { sessionId: { in: sessionIds } },
-        select: {
-          sessionId: true,
-          title: true,
-          expiredAt: true,
-          createdAt: true,
-        },
-        orderBy: {
-          createdAt: 'desc',
-        },
-      });
-      return sessions;
-    } catch (error) {
-      throw DatabaseException.read('UserSessionToken');
-    }
+    const userSessions = await this.prisma.userSessionToken.findMany({
+      where: { userId },
+      select: {
+        sessionId: true,
+      },
+    });
+    const sessionIds = userSessions.map((session) => session.sessionId);
+    return await this.prisma.session.findMany({
+      where: { sessionId: { in: sessionIds } },
+      select: {
+        sessionId: true,
+        title: true,
+        expiredAt: true,
+        createdAt: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
   }
 
   async updateSessionExpiredAt(sessionId: string, expireTime: Date) {
-    try {
-      await this.prisma.session.update({
-        where: {
-          sessionId,
-        },
-        data: { expiredAt: expireTime },
-      });
-    } catch (error) {
-      throw DatabaseException.update('session');
-    }
+    await this.prisma.session.update({
+      where: {
+        sessionId,
+      },
+      data: { expiredAt: expireTime },
+    });
   }
 }

--- a/apps/server/src/users/users.repository.ts
+++ b/apps/server/src/users/users.repository.ts
@@ -1,11 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 import { CreateUserDto } from './dto/create-user.dto';
-import { UserConflictException } from './exceptions/user.exception';
 
-import { DatabaseException } from '@common/exceptions/resource.exception';
-import { PRISMA_ERROR_CODE } from '@prisma-alias/prisma.error';
 import { PrismaService } from '@prisma-alias/prisma.service';
 
 @Injectable()
@@ -13,38 +9,18 @@ export class UsersRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(data: CreateUserDto) {
-    try {
-      await this.prisma.user.create({ data });
-    } catch (error) {
-      if (
-        error instanceof PrismaClientKnownRequestError &&
-        error.code === PRISMA_ERROR_CODE.UNIQUE_CONSTRAINT_VIOLATION
-      ) {
-        const [field] = (error.meta?.target as string[]) || [];
-        throw UserConflictException.duplicateField(field);
-      }
-
-      throw DatabaseException.create('user');
-    }
+    await this.prisma.user.create({ data });
   }
 
   async findByEmail(email: string) {
-    try {
-      return await this.prisma.user.findUnique({
-        where: { email },
-      });
-    } catch (error) {
-      throw DatabaseException.read('user');
-    }
+    return await this.prisma.user.findUnique({
+      where: { email },
+    });
   }
 
   async findByNickname(nickname: string) {
-    try {
-      return await this.prisma.user.findUnique({
-        where: { nickname },
-      });
-    } catch (error) {
-      throw DatabaseException.read('user');
-    }
+    return await this.prisma.user.findUnique({
+      where: { nickname },
+    });
   }
 }


### PR DESCRIPTION
## 개요
- repository에서 try catch문을 전부 제거하고 날 것의 에러를 필터에서 로깅하고 일괄되게 처리하도록 변경했습니다.
- 초기 렌더링 API에서 sessionId의 유효성을 검사하도록 추가했습니다.
- 웹소켓에서 세션과 토큰의 유효성을 검증하도록 추가했습니다.
## 이슈
- close #236 
